### PR TITLE
fix README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Basic mocking:
 
     @pook.on
     def test_my_api():
-        mock = pook.get('http://twitter.com/api/1/foobar', reply=404, response_json={'error': 'foo'})
+        mock = pook.get('http://twitter.com/api/1/foobar', reply=404, response_json={'error': 'not found'})
 
         resp = requests.get('http://twitter.com/api/1/foobar')
         assert resp.status_code == 404


### PR DESCRIPTION
Just a minor fix for the first **pook** usage example in the _README.rst_