### PR TITLE
Fix py27 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema~=2.5.1
 xmltodict~=0.10.2
 furl~=0.5.6
+mock~=2.0.0 ; python_version < '3.3'

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,11 @@ setup(
     py_modules=['pook'],
     zip_safe=False,
     install_requires=install_requires,
+    extras_require={
+        ':python_version < "3.3"': [
+            'mock~=2.0.0',
+        ],
+    },
     tests_require=tests_require,
     packages=find_packages(exclude=['tests', 'examples', 'docs']),
     package_data={'': [


### PR DESCRIPTION
Considering first example from the README:

```python
import pook
import requests

@pook.on
def test_my_api():
    mock = pook.get('http://twitter.com/api/1/foobar', reply=404, response_json={'error': 'not found'})

    resp = requests.get('http://twitter.com/api/1/foobar')
    assert resp.status_code == 404
    assert resp.json() == {"error": "not found"}
    assert mock.calls == 1

test_my_api()
```

Running it under Python 2.7.* results in the following traceback:

```
Traceback (most recent call last):
  File "example1.py", line 1, in <module>
    import pook
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/__init__.py", line 1, in <module>
    from .api import *  # noqa
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/api.py", line 5, in <module>
    from .engine import Engine
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/engine.py", line 5, in <module>
    from .mock_engine import MockEngine
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/mock_engine.py", line 1, in <module>
    from .interceptors import interceptors
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/interceptors/__init__.py", line 2, in <module>
    from .urllib3 import Urllib3Interceptor
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/interceptors/urllib3.py", line 5, in <module>
    from .http import URLLIB3_BYPASS
  File "/usr/local/var/pyenv/versions/pook-py27/lib/python2.7/site-packages/pook/interceptors/http.py", line 10, in <module>
    from unittest import mock
ImportError: cannot import name mock
```

The problem is caused by the following code section from **pook.interceptors.http**:

```python
# Support Python 2/3
try:
    import mock
except:
    from unittest import mock
```

**mock** is available as **unittest.mock** in Python 3.3 onwards, for Python 2.6 / 2.7 the backport should be installed https://pypi.python.org/pypi/mock

So, this PR updates _requirements.txt_ with _mock~=2.0.0_ and appropriate environment marker to properly handle `make install`. The same is done for **setup.py**.