### PR TITLE
Added a parameter to reply to force creation

### DIFF
--- a/pook/mock.py
+++ b/pook/mock.py
@@ -571,7 +571,7 @@ class Mock(object):
         """
         self._error = RuntimeError(error) if isinstance(error, str) else error
 
-    def reply(self, status=200, **kw):
+    def reply(self, status=200, create=False, **kw):
         """
         Defines the mock response.
 
@@ -584,7 +584,10 @@ class Mock(object):
             pook.Response: mock response definition instance.
         """
         # Use or create a Response mock instance
-        res = self._response or Response(**kw)
+        if create or not self._response:
+            res = Response(**kw)
+        else:
+            res = self._response
         # Define HTTP mandatory response status
         res.status(status or res._status)
         # Expose current mock instance in response for self-reference

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -16,3 +16,9 @@ def matcher(mock):
 def test_mock_url(mock):
     mock.url('http://google.es')
     assert str(matcher(mock)) == 'http://google.es'
+
+
+def test_mock_force_new_reply(mock):
+    res = mock._response
+    assert res == mock.reply()
+    assert res != mock.reply(create=True)


### PR DESCRIPTION
In a recent project, I found myself having to replace the mock's `_response` several times in callbacks and I had to set the attribute to `None` before calling `.reply` again so that a new response was actually created. Otherwise, it reuses the existing `_response`.

Adding an attribute to `reply` to force creation seems simpler.