### PR TITLE
Always use overwritten response

### DIFF
--- a/pook/mock.py
+++ b/pook/mock.py
@@ -571,7 +571,7 @@ class Mock(object):
         """
         self._error = RuntimeError(error) if isinstance(error, str) else error
 
-    def reply(self, status=200, **kw):
+    def reply(self, status=200, new_response=False, **kw):
         """
         Defines the mock response.
 
@@ -584,7 +584,7 @@ class Mock(object):
             pook.Response: mock response definition instance.
         """
         # Use or create a Response mock instance
-        res = Response(**kw)
+        res = Response(**kw) if new_response else self._response
         # Define HTTP mandatory response status
         res.status(status or res._status)
         # Expose current mock instance in response for self-reference

--- a/pook/mock.py
+++ b/pook/mock.py
@@ -584,7 +584,7 @@ class Mock(object):
             pook.Response: mock response definition instance.
         """
         # Use or create a Response mock instance
-        res = self._response or Response(**kw)
+        res = Response(**kw)
         # Define HTTP mandatory response status
         res.status(status or res._status)
         # Expose current mock instance in response for self-reference

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -16,3 +16,7 @@ def matcher(mock):
 def test_mock_url(mock):
     mock.url('http://google.es')
     assert str(matcher(mock)) == 'http://google.es'
+
+
+def test_new_response(mock):
+    assert(mock.reply() != mock.reply(new_response=True, json={}))


### PR DESCRIPTION
Not sure if this is a bug, so this PR is trying to start a discussion.

It looks like this `or` check will always ignore the later part since `self._response` is never None (from __init__ it'll at least get default value `Response()`.

The proposed solution is: If `reply` is called, then Mock should always use provided args to be response instead of checking with `_response`.

My use case is, I have a callback function that use `reply` to modify the response dynamically. Maybe there's a better way to do that.

Thank you!