### PR TITLE
Fix TypeError in use_network_filters by extending list with tuple

### DIFF
--- a/pook/engine.py
+++ b/pook/engine.py
@@ -117,7 +117,7 @@ class Engine(object):
         Arguments:
             *fn (function): variadic function filter arguments to be used.
         """
-        self.network_filters = self.network_filters + fn
+        self.network_filters.extend(fn)
 
     def flush_network_filters(self):
         """

--- a/tests/unit/engine_test.py
+++ b/tests/unit/engine_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pook import Engine
+
+
+@pytest.fixture
+def engine():
+    return Engine()
+
+
+def test_engine_use_network_filter(engine):
+    assert len(engine.network_filters) == 0
+    engine.use_network_filter(lambda x: x)
+    assert len(engine.network_filters) == 1
+
+
+def test_engine_enable_network(engine):
+    assert len(engine.network_filters) == 0
+    engine.enable_network('http://foo', 'http://bar')
+    assert len(engine.network_filters) == 2


### PR DESCRIPTION
As mentioned in issue #58, `enable_network` was not working when passing in a hostname. I have fixed the TypeError being raised, by extending the `network_filters` list in `use_network_filters` instead of the + concatenation that was being used.