### PR TITLE
update requirements for furl and jsonschema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema>=2.5.1
-xmltodict~=0.11.0
+xmltodict>=0.11.0
 furl>=0.5.6
-mock~=2.0.0 ; python_version < '3.3'
+mock>=2.0.0 ; python_version < '3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema~=2.5.1
+jsonschema>=2.5.1
 xmltodict~=0.11.0
-furl~=0.5.6
+furl>=0.5.6
 mock~=2.0.0 ; python_version < '3.3'


### PR DESCRIPTION
furl and jsonschema packages have been updated many revisions since 0.5 and 2.5 respectively, they are currently at 2.1 and 3.0. The requirements in this package forces a downgrade to these packages if the newer packages are already installed. This PR changes the requirements to be a "greater than" as to not force downgrades in an environment if the newer versions are already present.

Since  both furl and jsonschema are used with many conda (Anaconda) base installations this would happen frequently.