### PR TITLE
fix collections import warning

### DIFF
--- a/pook/headers.py
+++ b/pook/headers.py
@@ -1,5 +1,8 @@
 import sys
-from collections import Mapping, MutableMapping
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    from collections import Mapping, MutableMapping    
 
 PY3 = sys.version_info >= (3, 0)
 

--- a/pook/headers.py
+++ b/pook/headers.py
@@ -2,7 +2,7 @@ import sys
 try:
     from collections.abc import Mapping, MutableMapping
 except ImportError:
-    from collections import Mapping, MutableMapping    
+    from collections import Mapping, MutableMapping
 
 PY3 = sys.version_info >= (3, 0)
 


### PR DESCRIPTION
Starting in python 3.7 the following warning appears when importing from collections and not collections.abc, with the statement that it will no longer work in Python 3.8. This PR fixes the import to work across all python3 versions:

```
/usr/local/anaconda3/envs/prod/lib/python3.7/site-packages/pook/headers.py:2: 
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, MutableMapping
```
