### PR TITLE
Mocking chunked responses

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -116,6 +116,13 @@ Using ``urllib3`` as HTTP client
 
 
 
+Using ``urllib3`` to return a chunked response
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../examples/urllib3_chunked_response.py
+
+
+
 Asynchronous HTTP request using ``aiohttp``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/urllib3_chunked_response.py
+++ b/examples/urllib3_chunked_response.py
@@ -1,0 +1,14 @@
+import pook
+import urllib3
+
+
+# Mock HTTP traffic only in the given context
+with pook.use():
+    (pook.get('httpbin.org/chunky')
+        .reply(200)
+        .body(['returned', 'as', 'chunks'], chunked=True))
+
+    # Intercept request
+    http = urllib3.PoolManager()
+    r = http.request('GET', 'httpbin.org/chunky')
+    print('Chunks:', list(r.read_chunked()))

--- a/pook/interceptors/urllib3.py
+++ b/pook/interceptors/urllib3.py
@@ -11,9 +11,15 @@ except Exception:
     from unittest import mock
 
 if sys.version_info < (3,):     # Python 2
-    from httplib import responses as http_reasons
+    from httplib import (
+        responses as http_reasons,
+        HTTPResponse as ClientHTTPResponse,
+    )
 else:                           # Python 3
-    from http.client import responses as http_reasons
+    from http.client import (
+        responses as http_reasons,
+        HTTPResponse as ClientHTTPResponse,
+    )
 
 PATCHES = (
     'requests.packages.urllib3.connectionpool.HTTPConnectionPool.urlopen',
@@ -48,6 +54,17 @@ def body_io(string, encoding='utf-8'):
     return io.BytesIO(string)
 
 
+def is_chunked_response(headers):
+    tencoding = dict(headers).get("Transfer-Encoding", "").lower()
+    return "chunked" in tencoding.split(",")
+
+
+class MockSock(object):
+    @classmethod
+    def makefile(cls, *args, **kwargs):
+        return
+
+
 class FakeHeaders(list):
     def get_all(self, key, default=None):
         key = key.lower()
@@ -56,11 +73,38 @@ class FakeHeaders(list):
 
 
 class FakeResponse(object):
-    def __init__(self, headers):
+    def __init__(self, method, headers):
+        self._method = method  # name expected by urllib3
         self.msg = FakeHeaders(headers)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
 
     def isclosed(self):
-        return False
+        return self.closed
+
+
+class FakeChunkedResponseBody(object):
+    def __init__(self, chunks):
+        self.index = 0
+        self.chunks = chunks
+        self.closed = False
+
+    def read_chunk(self, amt=-1):
+        pass
+
+    def readline(self):
+        return self.read_chunk()
+
+    def read(self, amt=-1):
+        return self.read_chunk(amt)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
 
 
 class Urllib3Interceptor(BaseInterceptor):
@@ -96,23 +140,34 @@ class Urllib3Interceptor(BaseInterceptor):
         if not mock:
             return urlopen(pool, method, url, body=body, headers=headers, **kw)
 
-        # Shortcut to mock response
+        # Shortcut to mock response and response body
         res = mock._response
+        body = res._body
 
         # Aggregate headers as list of tuples for interface compatibility
         headers = []
         for key in res._headers:
             headers.append((key, res._headers[key]))
 
+        if is_chunked_response(headers):
+            body_chunks = body if isinstance(body, list) else [body]
+            body_chunks = [body_io(chunk) for chunk in body_chunks]
+
+            body = ClientHTTPResponse(MockSock)
+            body.fp = FakeChunkedResponseBody(body_chunks)
+        else:
+            # Assume that the body is a bytes-like object
+            body = body_io(body)
+
         # Return mocked HTTP response
         return HTTPResponse(
             path,
-            body=body_io(res._body),
+            body=body,
             status=res._status,
             headers=headers,
             preload_content=False,
             reason=http_reasons.get(res._status),
-            original_response=FakeResponse(headers),
+            original_response=FakeResponse(method, headers),
         )
 
     def _patch(self, path):

--- a/pook/response.py
+++ b/pook/response.py
@@ -145,12 +145,13 @@ class Response(object):
         self._headers['Content-Type'] = TYPES.get(name, name)
 
     @fluent
-    def body(self, body):
+    def body(self, body, chunked=False):
         """
         Defines response body data.
 
         Arguments:
             body (str|bytes|list): response body to use.
+            chunked (bool): return a chunked response.
 
         Returns:
             self: ``pook.Response`` current instance.
@@ -159,6 +160,9 @@ class Response(object):
             body = body.decode('utf-8')
 
         self._body = body
+
+        if chunked:
+            self.header('Transfer-Encoding', 'chunked')
 
     @fluent
     def json(self, data):

--- a/pook/response.py
+++ b/pook/response.py
@@ -150,7 +150,7 @@ class Response(object):
         Defines response body data.
 
         Arguments:
-            body (str|bytes): response body to use.
+            body (str|bytes|list): response body to use.
 
         Returns:
             self: ``pook.Response`` current instance.

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+import urllib3
+import pook
+
+
+@pook.on
+def test_chunked_response_list():
+    (pook.get('httpbin.org/foo')
+        .reply(204)
+        .header('Transfer-Encoding', 'chunked')
+        .body(['a', 'b', 'c']))
+
+    http = urllib3.PoolManager()
+    r = http.request('GET', 'httpbin.org/foo')
+
+    assert r.status == 204
+    assert list(r.read_chunked()) == ['a', 'b', 'c']
+
+
+@pook.on
+def test_chunked_response_str():
+    (pook.get('httpbin.org/foo')
+        .reply(204)
+        .header('Transfer-Encoding', 'chunked')
+        .body('text'))
+
+    http = urllib3.PoolManager()
+    r = http.request('GET', 'httpbin.org/foo')
+
+    assert r.status == 204
+    assert list(r.read_chunked()) == ['text']
+
+
+@pook.on
+def test_chunked_response_byte():
+    (pook.get('httpbin.org/foo')
+        .reply(204)
+        .header('Transfer-Encoding', 'chunked')
+        .body(b'byteman'))
+
+    http = urllib3.PoolManager()
+    r = http.request('GET', 'httpbin.org/foo')
+
+    assert r.status == 204
+    assert list(r.read_chunked()) == ['byteman']
+
+
+@pook.on
+def test_chunked_response_empty():
+    (pook.get('httpbin.org/foo')
+        .reply(204)
+        .header('Transfer-Encoding', 'chunked')
+        .body(''))
+
+    http = urllib3.PoolManager()
+    r = http.request('GET', 'httpbin.org/foo')
+
+    assert r.status == 204
+    assert list(r.read_chunked()) == []

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -8,8 +8,7 @@ import pook
 def test_chunked_response_list():
     (pook.get('httpbin.org/foo')
         .reply(204)
-        .header('Transfer-Encoding', 'chunked')
-        .body(['a', 'b', 'c']))
+        .body(['a', 'b', 'c'], chunked=True))
 
     http = urllib3.PoolManager()
     r = http.request('GET', 'httpbin.org/foo')
@@ -22,8 +21,7 @@ def test_chunked_response_list():
 def test_chunked_response_str():
     (pook.get('httpbin.org/foo')
         .reply(204)
-        .header('Transfer-Encoding', 'chunked')
-        .body('text'))
+        .body('text', chunked=True))
 
     http = urllib3.PoolManager()
     r = http.request('GET', 'httpbin.org/foo')
@@ -36,8 +34,7 @@ def test_chunked_response_str():
 def test_chunked_response_byte():
     (pook.get('httpbin.org/foo')
         .reply(204)
-        .header('Transfer-Encoding', 'chunked')
-        .body(b'byteman'))
+        .body(b'byteman', chunked=True))
 
     http = urllib3.PoolManager()
     r = http.request('GET', 'httpbin.org/foo')
@@ -50,11 +47,23 @@ def test_chunked_response_byte():
 def test_chunked_response_empty():
     (pook.get('httpbin.org/foo')
         .reply(204)
-        .header('Transfer-Encoding', 'chunked')
-        .body(''))
+        .body('', chunked=True))
 
     http = urllib3.PoolManager()
     r = http.request('GET', 'httpbin.org/foo')
 
     assert r.status == 204
     assert list(r.read_chunked()) == []
+
+
+@pook.on
+def test_chunked_response_contains_newline():
+    (pook.get('httpbin.org/foo')
+        .reply(204)
+        .body('newline\r\n', chunked=True))
+
+    http = urllib3.PoolManager()
+    r = http.request('GET', 'httpbin.org/foo')
+
+    assert r.status == 204
+    assert list(r.read_chunked()) == ['newline\r\n']


### PR DESCRIPTION
This PR extends `pook`'s API to allow configuring a chunked response (only supported for `urllib3`).

Example:
```
import pook
import urllib3

# Mock HTTP traffic only in the given context
with pook.use():
    (pook.get('httpbin.org/chunky')
        .reply(200)
        .body(['returned', 'as', 'chunks'], chunked=True))

    # Intercept request
    http = urllib3.PoolManager()
    r = http.request('GET', 'httpbin.org/chunky')
    print('Chunks:', list(r.read_chunked()))
```

- [x] implemenation
- [x] tests
- [x] documentation