### PR TITLE
Fix latest aiohttp

### DIFF
--- a/pook/interceptors/aiohttp.py
+++ b/pook/interceptors/aiohttp.py
@@ -42,7 +42,8 @@ class SimpleContent(EmptyStreamReader):
         super().__init__(*args, **kwargs)
         self.content = content
 
-    async def read(self, n=-1):
+    @asyncio.coroutine
+    def read(self, n=-1):
         return self.content
 
 

--- a/pook/interceptors/aiohttp.py
+++ b/pook/interceptors/aiohttp.py
@@ -62,7 +62,7 @@ def HTTPResponse(*args, **kw):
         traces=[],
         loop=mock.Mock(),
         session=mock.Mock(),
-        **kw,
+        **kw
     )
 
 

--- a/pook/interceptors/aiohttp.py
+++ b/pook/interceptors/aiohttp.py
@@ -1,8 +1,6 @@
 import sys
 from ..request import Request
 from .base import BaseInterceptor
-from aiohttp.helpers import TimerNoop
-from aiohttp.streams import EmptyStreamReader
 
 # Support Python 2/3
 try:
@@ -19,8 +17,12 @@ else:                           # Python 3
 
 if sys.version_info >= (3, 4, 2):  # Python 3.4.2+
     import asyncio
+    from aiohttp.helpers import TimerNoop
+    from aiohttp.streams import EmptyStreamReader
 else:
     asyncio = None
+    TimerNoop = None
+    EmptyStreamReader = None
 
 # Try to load yarl URL parser package used by aiohttp
 try:

--- a/pook/interceptors/aiohttp.py
+++ b/pook/interceptors/aiohttp.py
@@ -1,6 +1,8 @@
 import sys
 from ..request import Request
 from .base import BaseInterceptor
+from aiohttp.helpers import TimerNoop
+from aiohttp.streams import EmptyStreamReader
 
 # Support Python 2/3
 try:
@@ -9,10 +11,10 @@ except Exception:
     from unittest import mock
 
 if sys.version_info < (3,):     # Python 2
-    from urlparse import urlunparse
+    from urlparse import urlunparse, urlencode
     from httplib import responses as http_reasons
 else:                           # Python 3
-    from urllib.parse import urlunparse
+    from urllib.parse import urlunparse, urlencode
     from http.client import responses as http_reasons
 
 if sys.version_info >= (3, 4, 2):  # Python 3.4.2+
@@ -35,13 +37,32 @@ RESPONSE_CLASS = 'ClientResponse'
 RESPONSE_PATH = 'aiohttp.client_reqrep'
 
 
+class SimpleContent(EmptyStreamReader):
+    def __init__(self, content, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.content = content
+
+    async def read(self, n=-1):
+        return self.content
+
+
 def HTTPResponse(*args, **kw):
     # Dynamically load package
     module = __import__(RESPONSE_PATH, fromlist=(RESPONSE_CLASS,))
     ClientResponse = getattr(module, RESPONSE_CLASS)
 
     # Return response instance
-    return ClientResponse(*args, **kw)
+    return ClientResponse(
+        *args,
+        request_info=mock.Mock(),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock(),
+        **kw,
+    )
 
 
 class AIOHTTPInterceptor(BaseInterceptor):
@@ -64,7 +85,12 @@ class AIOHTTPInterceptor(BaseInterceptor):
         req.extra = kw
 
         # Compose URL
-        req.url = str(url)
+        if not kw.get('params'):
+            req.url = str(url)
+        else:
+            req.url = str(url) + '?' + urlencode(
+                [(x, y) for x, y in kw['params'].items()]
+            )
 
         # Match the request against the registered mocks in pook
         mock = self.engine.match(req)
@@ -98,16 +124,19 @@ class AIOHTTPInterceptor(BaseInterceptor):
         _res._should_close = False
 
         # Add response headers
-        _res.raw_headers = tuple(headers)
-        _res.headers = multidict.CIMultiDictProxy(
+        _res._raw_headers = tuple(headers)
+        _res._headers = multidict.CIMultiDictProxy(
             multidict.CIMultiDict(headers)
         )
 
-        # Define `_content` attribute with an empty string to
-        # force do not read from stream (which won't exists)
-        _res._content = ''
         if res._body:
-            _res._content = res._body.encode('utf-8', errors='replace')
+            _res.content = SimpleContent(
+                res._body.encode('utf-8', errors='replace'),
+            )
+        else:
+            # Define `_content` attribute with an empty string to
+            # force do not read from stream (which won't exists)
+            _res.content = EmptyStreamReader()
 
         # Return response based on mock definition
         return _res

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,5 @@ sphinx-rtd-theme~=0.1.9
 requests>=2.20.0
 urllib3>=1.24.2
 bumpversion~=0.5.3
-aiohttp~=1.1.5 ; python_version >= '3.4.2'
+aiohttp~=3.6.2 ; python_version >= '3.4.2'
 mocket~=1.6.0


### PR DESCRIPTION
We had two issues, params didn't make it through with the example call:

``` python
    async with aiohttp.ClientSession(loop=loop) as session:
        async with session.get(
            url, params={'foo': 'bar'},
        ) as r:
```

and the latest version of aiohttp changed some interface patterns.

This is a quick hack to get `aiohttp==3.6.2` working.  I expect changes to be requested, but I wanted to open the PR to get some feedback on the changes so far.

Fixes https://github.com/h2non/pook/issues/56