### PR TITLE
fix(urllib3): interceptor is never really disabled

### DIFF
--- a/pook/interceptors/urllib3.py
+++ b/pook/interceptors/urllib3.py
@@ -223,4 +223,5 @@ class Urllib3Interceptor(BaseInterceptor):
         Disables the traffic interceptor.
         This method must be implemented by any interceptor.
         """
-        [patch.stop() for patch in self.patchers]
+        patchers_reversed = self.patchers[::-1]
+        [patch.stop() for patch in patchers_reversed]

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -39,3 +39,13 @@ def test_chunked_response_empty():
 
 def test_chunked_response_contains_newline():
     assert_chunked_response('newline\r\n', ['newline\r\n'])
+
+
+def test_activate_disable():
+    original = urllib3.connectionpool.HTTPConnectionPool.urlopen
+
+    interceptor = pook.interceptors.Urllib3Interceptor(pook.MockEngine)
+    interceptor.activate()
+    interceptor.disable()
+
+    assert urllib3.connectionpool.HTTPConnectionPool.urlopen == original


### PR DESCRIPTION
The `urllib3` interceptor is never really disabled - see the committed unit test.

My assumption is that this is because of the two patches - the native one and the `requests` one presumably point to the same function. When the first mock is created it points to the original, while at the time of creation of the second mock, it will the point to the already mocked version.

The fix is to stop the mocks in reverse order.