### PR TITLE
Fixing #72 issue

### DIFF
--- a/pook/interceptors/base.py
+++ b/pook/interceptors/base.py
@@ -1,4 +1,10 @@
 from abc import abstractmethod, ABCMeta
+import inspect
+# Support Python 2/3
+try:
+    import mock
+except Exception:
+    from unittest import mock
 
 
 class BaseInterceptor(object):
@@ -8,6 +14,7 @@ class BaseInterceptor(object):
     """
 
     __metaclass__ = ABCMeta
+    _static_patchers = {}
 
     def __init__(self, engine):
         self.patchers = []
@@ -20,18 +27,82 @@ class BaseInterceptor(object):
         """
         return type(self).__name__
 
+    @staticmethod
+    def _get_real_import_path(path):
+        # inspired (a.k.a copy pasted)
+        # by unittest.mock module and functions:
+        # _get_target, _importer, _dot_lookup
+
+        def _dot_lookup(thing, comp, import_path):
+            try:
+                return getattr(thing, comp)
+            except AttributeError:
+                __import__(import_path)
+                return getattr(thing, comp)
+
+        target, attribute = path.rsplit('.', 1)
+
+        components = target.split('.')
+        import_path = components.pop(0)
+        thing = __import__(import_path)
+
+        for comp in components:
+            import_path += ".%s" % comp
+            thing = _dot_lookup(thing, comp, import_path)
+        thing_module_path = inspect.getmodule(thing).__name__
+        thing_module_path += "." + ".".join(path.rsplit(".", 2)[1:])
+
+        return thing_module_path
+
+    def _patch(self, path):
+        def _decorator(fn):
+            def wrapped(*args, **kwargs):
+                return fn(request, path, *args, **kwargs)
+            return wrapped
+
+        try:
+            real_module_path = self._get_real_import_path(path)
+            if real_module_path in BaseInterceptor._static_patchers:
+                # TODO: add warning here
+                return
+            # Create a new patcher for `request` function
+            # used as entry point for all the HTTP communications
+            patcher = mock.patch(path, _decorator(self._patch_handler))
+            patcher._real_module_path = real_module_path
+            # Retrieve original patched function that we might need for real
+            # networking
+            request = patcher.get_original()[0]
+            # Start patching function calls
+            patcher.start()
+        except AssertionError:
+            raise
+        except Exception:
+            # Exceptions may accur due to missing package
+            # Ignore all the exceptions for now
+            pass
+        else:
+            self.patchers.append(patcher)
+            BaseInterceptor._static_patchers[real_module_path] = patcher
+
+    def _patch_handler(self, *args, **kwargs):
+        raise NotImplementedError
+
     @abstractmethod
     def activate(self):
         """
         Activates the traffic interceptor.
         This method must be implemented by any interceptor.
         """
-        pass
+        [self._patch(patch) for patch in self.PATCHES]
 
-    @abstractmethod
     def disable(self):
         """
         Disables the traffic interceptor.
         This method must be implemented by any interceptor.
         """
-        pass
+        for patch in reversed(self.patchers):
+            patch.stop()
+            if patch._real_module_path in BaseInterceptor._static_patchers:
+                del BaseInterceptor._static_patchers[patch._real_module_path]
+
+

--- a/tests/unit/interceptors/bug_test.py
+++ b/tests/unit/interceptors/bug_test.py
@@ -9,5 +9,9 @@ class TestPookBug(unittest.TestCase):
         self.assertEqual(req.get("http://google.com").status_code, 201)
 
     def test_2_no_pook(self):
+        req.get("http://google.com")
+
+    def test_3_no_force_pook(self):
+        pook.on()
         pook.off()
         req.get("http://google.com")

--- a/tests/unit/interceptors/bug_test.py
+++ b/tests/unit/interceptors/bug_test.py
@@ -1,0 +1,13 @@
+import unittest
+import pook
+import requests as req
+
+
+class TestPookBug(unittest.TestCase):
+    @pook.get("http://google.com", reply=201)
+    def test_1_with_pook(self):
+        self.assertEqual(req.get("http://google.com").status_code, 201)
+
+    def test_2_no_pook(self):
+        pook.off()
+        req.get("http://google.com")


### PR DESCRIPTION
This PR fixes the #72 issue. A detailed description is available in the last commit.

I've achieved it by keeping track of the real module path when we do patching. For example when patching:
- `a.b.c`
- `d.e.f`

Somehow `a.b.c` can be equal to `d.e.f` so, when we trying to patch the second object we should check if it was already patched, and if it is, then I just skip it. 