### PR TITLE
Closes #57 Add support for urllib

### DIFF
--- a/pook/interceptors/http.py
+++ b/pook/interceptors/http.py
@@ -49,6 +49,16 @@ class HTTPClientInterceptor(BaseInterceptor):
     urllib / http.client HTTP traffic interceptor.
     """
 
+    @staticmethod
+    def _ensure_binary(func):
+        def wrapper():
+            data = func()
+            try:
+                return data.encode()
+            except AttributeError:
+                return data
+        return wrapper
+
     def _on_request(self, _request, conn, method, url,
                     body=None, headers=None, **kw):
         # Create request contract based on incoming params
@@ -93,7 +103,8 @@ class HTTPClientInterceptor(BaseInterceptor):
         # Path reader
         def read():
             return res._body or ''
-        mockres.read = read
+        mockres.read = self._ensure_binary(read)
+        mockres.code = mockres.status
 
         return mockres
 

--- a/tests/unit/interceptors/urllib_test.py
+++ b/tests/unit/interceptors/urllib_test.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import json
+from urllib.request import urlopen
+import pook
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def intercept():
+    pook.on()
+    yield
+    pook.off()
+
+
+def test_json_response_is_forwarder_successfuly():
+    (pook.get("httpjson.org/foo").reply(200).json({}))
+    r = urlopen("http://httpjson.org/foo")
+    assert r.status == 200
+    assert json.load(r) == {}
+
+
+@pytest.mark.parametrize(
+    'data,expected',
+    [('data', 'data'), (b'data', 'data')]
+)
+def test_binary_response_can_be_decoded(data, expected):
+    (pook.get("httpbin.org/foo").reply(200).body(data))
+    r = urlopen("http://httpbin.org/foo")
+    assert r.status == 200
+    assert r.read().decode() == expected


### PR DESCRIPTION
Some SDK's use `urllib` instead of `urllib3`, we use `pook` to intercept and mock the responses regardless of what the SDK uses underneat.

This PR includes the code that we use to "fix" the HTTPInterceptor to behave well with `urllib` in python3.

Also this PR is a bribe to try and get a `1.0.2` release :pray: :smile:

Closes #57 
