### PR TITLE
Fix Py3.11 compatibility

### DIFF
--- a/pook/activate_async.py
+++ b/pook/activate_async.py
@@ -1,5 +1,5 @@
 import functools
-from asyncio import iscoroutinefunction, coroutine
+from asyncio import iscoroutinefunction
 
 
 def activate_async(fn, _engine):
@@ -13,13 +13,13 @@ def activate_async(fn, _engine):
     Returns:
         function: decorator wrapper function.
     """
-    @coroutine
     @functools.wraps(fn)
-    def wrapper(*args, **kw):
+    async def wrapper(*args, **kw):
         _engine.activate()
         try:
             if iscoroutinefunction(fn):
-                yield from fn(*args, **kw)  # noqa
+                async for v in fn(*args, **kw):
+                    yield v
             else:
                 fn(*args, **kw)
         finally:

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -19,4 +19,4 @@ def test_mock_url(mock):
 
 
 def test_new_response(mock):
-    assert(mock.reply() != mock.reply(new_response=True, json={}))
+    assert mock.reply() != mock.reply(new_response=True, json={})

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37,py38,py39,py310,pypy}
+envlist = {py35,py36,py37,py38,py39,py310,py311,pypy}
 
 [testenv]
 setenv =


### PR DESCRIPTION
Remove asyncio.coroutine usage
    
The asyncio.coroutine doesn't exist in Python 3.11 and future versions:
https://github.com/python/cpython/issues/87382
    
See https://github.com/h2non/pook/issues/84