### PR TITLE
urllib3 v2+ support

### DIFF
--- a/pook/interceptors/urllib3.py
+++ b/pook/interceptors/urllib3.py
@@ -181,7 +181,7 @@ class Urllib3Interceptor(BaseInterceptor):
         def handler(conn, method, url, body=None, headers=None, **kw):
             # Flag that the current request as urllib3 intercepted
             headers = headers or {}
-            headers[URLLIB3_BYPASS] = True
+            headers[URLLIB3_BYPASS] = "1"
 
             # Call request interceptor
             return self._on_request(urlopen, path, conn, method, url,

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -82,3 +82,11 @@ def test_binary_body_chunked():
     r = http.request('GET', URL)
 
     assert list(r.read_chunked()) == [binary_file]
+
+
+def test_post_with_headers():
+    # this test failed with urllib3 v2.0.3
+    pook.post('https://example.org').reply(200)
+    http = urllib3.PoolManager(headers={'k': 'v'})
+    resp = http.request('POST', 'https://example.org')
+    assert resp.status == 200

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -11,7 +11,7 @@ binary_file = (
 ).read_bytes()
 
 
-URL = 'httpbin.org/foo'
+URL = 'https://httpbin.org/foo'
 
 
 @pook.on


### PR DESCRIPTION
Don't put non-strings into http header dict.

Closes #86 