### PR TITLE
Add examples and tests for matching query params

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -59,6 +59,11 @@ JSONSchema based body matching
 .. literalinclude:: ../examples/json_schema.py
 
 
+Request Query Params matching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../examples/query_params_matching.py
+
 
 Enable real networking mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/query_params_matching.py
+++ b/examples/query_params_matching.py
@@ -1,0 +1,19 @@
+import pook
+import requests
+
+# Enable mock engine
+pook.on()
+
+(
+    pook.get("httpbin.org/post")
+    .params({"foo": "bar"})
+    .reply(204)
+    .json({"error": "simulated"})
+)
+
+res = requests.get("http://httpbin.org/get", params={"foo": "bar"})
+print("Status:", res.status_code)
+print("Body:", res.json())
+
+print("Is done:", pook.isdone())
+print("Pending mocks:", pook.pending_mocks())

--- a/tests/integration/pook_requests_test.py
+++ b/tests/integration/pook_requests_test.py
@@ -32,3 +32,17 @@ def test_requests_match_url(mock):
     assert res.headers == {'Content-Type': 'application/json'}
     assert res.json() == body
     assert pook.isdone() is True
+
+
+def test_requests_match_query_params(mock):
+    body = {'foo': 'bar'}
+    (mock.get('http://foo.com')
+        .params({'foo': 'bar'})
+        .reply(200)
+        .json(body))
+
+    res = requests.get('http://foo.com', params={'foo': 'bar'})
+    assert res.status_code == 200
+    assert res.headers == {'Content-Type': 'application/json'}
+    assert res.json() == body
+    assert pook.isdone() is True

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pook.mock import Mock
+from pook.request import Request
 
 
 @pytest.fixture
@@ -14,8 +15,63 @@ def matcher(mock):
 
 
 def test_mock_url(mock):
-    mock.url('http://google.es')
-    assert str(matcher(mock)) == 'http://google.es'
+    mock.url("http://google.es")
+    assert str(matcher(mock)) == "http://google.es"
+
+
+@pytest.mark.parametrize(
+    "url, params, req, expected",
+    [
+        ("http://google.es", {}, Request(url="http://google.es"), (True, [])),
+        (
+            "http://google.es",
+            {},
+            Request(url="http://google.es?foo=bar"),
+            (True, []),
+        ),
+        (
+            "http://google.es",
+            {},
+            Request(url="http://google.es?foo=bar&baz=qux"),
+            (True, []),
+        ),
+        (
+            "http://google.es",
+            {},
+            Request(url="http://google.es?baz=qux"),
+            (True, []),
+        ),
+        (
+            "http://google.es",
+            {"foo": "bar"},
+            Request(url="http://google.es"),
+            (False, []),
+        ),
+        (
+            "http://google.es",
+            {"foo": "bar"},
+            Request(url="http://google.es?foo=bar"),
+            (True, []),
+        ),
+        (
+            "http://google.es",
+            {"foo": "bar"},
+            Request(url="http://google.es?foo=bar&baz=qux"),
+            (True, []),
+        ),
+        (
+            "http://google.es",
+            {"foo": "bar"},
+            Request(url="http://google.es?baz=qux"),
+            (False, []),
+        ),
+    ],
+)
+def test_mock_params(url, params, req, expected, mock):
+    mock.url(url)
+    if params:
+        mock.params(params)
+    assert mock.matchers.match(req) == expected
 
 
 def test_new_response(mock):


### PR DESCRIPTION
Hi,

Thank you for your marvelous library, it saved a lot of hours in testing different integrations 🤩

However, the documentation misses examples regarding matching query parameters.

Have spent some time to figure our that it should be declared in the next way 

```python
pook.get("https://google.com").params({"q": "I need coffee"})
```

but throws an exception, if pass it as a keyword parameter

```python
pook.get("https://google.com", params={"q": "Nooooo!"})
```


So, I would like to contribute a bit to the project by adding tests and examples to the documentation. 
Hope it will save time for another developer 🍸