### PR TITLE
Revert unnecessary dependencies upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonschema~=4.0
-xmltodict>=0.13.0
-furl>=2.1.3
+jsonschema>=2.5.1
+xmltodict>=0.11.0
+furl>=0.5.6


### PR DESCRIPTION
The constraints I added in #92 does not make sense. Reverting those changes for now and I'll use less rigid versions in a follow up.