### PR TITLE
More reliable test_post_with_headers

### DIFF
--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -94,8 +94,8 @@ def test_binary_body_chunked():
     )
 )
 def test_post_with_headers(pook_on):
-    mock = pook.post('https://example.com').header('k', 'v').reply(200).mock
+    mock = pook.post(URL).header('k', 'v').reply(200).mock
     http = urllib3.PoolManager(headers={'k': 'v'})
-    resp = http.request('POST', 'https://example.com', headers={'k': 'v'})
+    resp = http.request('POST', URL)
     assert resp.status == 200
     assert len(mock.matches) == 1


### PR DESCRIPTION
This will make the test fail if the mock hasn't matched (in the original PR it failed for other reason, earlier, not because of a mock mismatch).

By using https://httpbin.org/foo instead of https://example.com, the `resp.status` will be 404 instead of 200 if the mock didn't apply successfully. That's a less confusing failure mode.