### PR TITLE
Enable mocket tests for >3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,8 @@ extra-dependencies = [
     # async-timeout is only used for testing aiohttp
     "aiohttp~=3.8; python_version < '3.12'",
     "async-timeout~=4.0.3; python_version < '3.12'",
-    # mocket disabled pook for 3.11 due to pook's compatibility issues
-    # https://github.com/mindflayer/python-mocket/issues/210
-    # Once that issue is resolved, we can re-enable mocket testing for all versions
     # mocket relies on httptools which does not support PyPy
-    "mocket[pook]~=3.12.0; python_version < '3.11' and platform_python_implementation != 'PyPy'",
+    "mocket[pook]~=3.12.2; platform_python_implementation != 'PyPy'",
 ]
 
 [tool.hatch.envs.lint]

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -9,7 +9,8 @@ examples_dir = Path(__file__).parents[2] / "examples"
 
 examples = [f.name for f in examples_dir.glob("*.py")]
 
-if sys.version_info >= (3, 11) or platform.python_implementation() == "PyPy":
+
+if platform.python_implementation() == "PyPy":
     # See pyproject.toml note on mocket dependency
     examples.remove("mocket_example.py")
 


### PR DESCRIPTION
Made possible by https://github.com/mindflayer/python-mocket/pull/211