### PR TITLE
Fix `Mock` constructor params/url order mishandling

### DIFF
--- a/src/pook/mock.py
+++ b/src/pook/mock.py
@@ -96,6 +96,46 @@ class Mock(object):
         pook.Mock
     """
 
+    _KEY_ORDER = (
+        "add_matcher",
+        "body",
+        "callback",
+        "calls",
+        "content",
+        "delay",
+        "done",
+        "error",
+        "file",
+        "filter",
+        "header",
+        "header_present",
+        "headers",
+        "headers_present",
+        "isdone",
+        "ismatched",
+        "json",
+        "jsonschema",
+        "map",
+        "match",
+        "matched",
+        "matches",
+        "method",
+        "url",
+        "param",
+        "param_exists",
+        "params",
+        "path",
+        "persist",
+        "reply",
+        "response",
+        "status",
+        "times",
+        "total_matches",
+        "type",
+        "use",
+        "xml",
+    )
+
     def __init__(self, request=None, response=None, **kw):
         # Stores the number of times the mock should live
         self._times = 1
@@ -126,7 +166,7 @@ class Mock(object):
         self.callbacks = []
 
         # Triggers instance methods based on argument names
-        trigger_methods(self, kw)
+        trigger_methods(self, kw, self._KEY_ORDER)
 
         # Trigger matchers based on predefined request object, if needed
         if request:

--- a/src/pook/request.py
+++ b/src/pook/request.py
@@ -44,7 +44,7 @@ class Request(object):
         self._extra = kw.get("extra")
         self._headers = HTTPHeaderDict()
 
-        trigger_methods(self, kw)
+        trigger_methods(self, kw, self.keys)
 
     @property
     def method(self):

--- a/src/pook/response.py
+++ b/src/pook/response.py
@@ -23,6 +23,20 @@ class Response(object):
         mock (pook.Mock): reference to mock instance.
     """
 
+    _KEY_ORDER = (
+        "body",
+        "content",
+        "file",
+        "header",
+        "headers",
+        "json",
+        "mock",
+        "set",
+        "status",
+        "type",
+        "xml",
+    )
+
     def __init__(self, **kw):
         self._status = 200
         self._mock = None
@@ -31,7 +45,7 @@ class Response(object):
         self._headers = HTTPHeaderDict()
 
         # Trigger response method based on input arguments
-        trigger_methods(self, kw)
+        trigger_methods(self, kw, self._KEY_ORDER)
 
     def status(self, code=200):
         """

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -1,6 +1,12 @@
 import pytest
+import json
+import re
+
+import pook
 from pook.mock import Mock
 from pook.request import Request
+from urllib.request import urlopen
+from urllib.parse import urlencode
 
 
 @pytest.fixture
@@ -15,6 +21,47 @@ def matcher(mock):
 def test_mock_url(mock):
     mock.url("http://google.es")
     assert str(matcher(mock)) == "http://google.es"
+
+
+@pytest.mark.parametrize(
+    ("param_kwargs", "query_string"),
+    (
+        pytest.param({"params": {"x": "1"}}, "?x=1", id="params"),
+        pytest.param(
+            {"param": ("y", "pook")},
+            "?y=pook",
+            marks=pytest.mark.xfail(
+                condition=True,
+                reason="Constructor does not correctly handle multi-argument methods from kwargs",
+            ),
+            id="param",
+        ),
+        pytest.param(
+            {"param_exists": "z"},
+            # This complexity is needed until https://github.com/h2non/pook/issues/110
+            # is resolved
+            f'?{urlencode({"z": re.compile("(.*)")})}',
+            id="param_exists",
+        ),
+    ),
+)
+def test_constructor(param_kwargs, query_string):
+    # Should not raise
+    mock = Mock(
+        url="https://httpbin.org/404",
+        reply_status=200,
+        response_json={"hello": "from pook"},
+        **param_kwargs,
+    )
+
+    expected_url = f"https://httpbin.org/404{query_string}"
+    assert mock._request.rawurl == expected_url
+
+    with pook.use():
+        pook.engine().add_mock(mock)
+        res = urlopen(expected_url)
+        assert res.status == 200
+        assert json.loads(res.read()) == {"hello": "from pook"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #104 by using an explicit order to trigger methods on `Mock`.

This does not handle the case where query param arguments are passed without `url` at all. That will continue to raise an exception, which is intentional until a bigger change can be made to make the mock lazy and self-validating.