### PR TITLE
Optionally match empty values in query parameter presence matcher

### DIFF
--- a/src/pook/matchers/api.py
+++ b/src/pook/matchers/api.py
@@ -1,9 +1,9 @@
 from .base import BaseMatcher
 from .url import URLMatcher
 from .body import BodyMatcher
-from .query import QueryMatcher
+from .query import QueryMatcher, QueryParameterExistsMatcher
 from .method import MethodMatcher
-from .headers import HeadersMatcher
+from .headers import HeadersMatcher, HeaderExistsMatcher
 from .path import PathMatcher
 from .xml import XMLMatcher
 from .json import JSONMatcher
@@ -34,6 +34,7 @@ matchers = [
     MethodMatcher,
     URLMatcher,
     HeadersMatcher,
+    HeaderExistsMatcher,
     QueryMatcher,
     PathMatcher,
     BodyMatcher,
@@ -41,6 +42,7 @@ matchers = [
     JSONMatcher,
     JSONSchemaMatcher,
     QueryMatcher,
+    QueryParameterExistsMatcher,
 ]
 
 

--- a/src/pook/matchers/headers.py
+++ b/src/pook/matchers/headers.py
@@ -1,4 +1,4 @@
-from .base import BaseMatcher
+from .base import BaseMatcher, ExistsMatcher
 from ..headers import to_string_value
 from ..regex import Pattern
 
@@ -53,3 +53,7 @@ class HeadersMatcher(BaseMatcher):
             return value
 
         return to_string_value(value)
+
+
+class HeaderExistsMatcher(ExistsMatcher):
+    request_attr = "headers"

--- a/src/pook/matchers/query.py
+++ b/src/pook/matchers/query.py
@@ -45,3 +45,27 @@ class QueryMatcher(BaseMatcher):
 
 class QueryParameterExistsMatcher(ExistsMatcher):
     request_attr = "query"
+
+    def __init__(self, expectation, allow_empty, negate=False):
+        super().__init__(expectation, negate)
+        self.allow_empty = allow_empty
+
+    def match(self, request):
+        if not super().match(request):
+            return False
+
+        if not self.allow_empty:
+            attribute = self.get_request_attribute(request)
+            assert not self.is_empty(
+                attribute[self.expectation]
+            ), f"The request's {self.expectation} query parameter was unexpectedly empty."
+
+        return True
+
+    def is_empty(self, value):
+        """
+        Check for empty query parameter values.
+
+        `urllib.parse.parse_qs` returns a value of `['']` for parameters that are present but without value.
+        """
+        return not value or value == [""]

--- a/src/pook/matchers/query.py
+++ b/src/pook/matchers/query.py
@@ -1,4 +1,4 @@
-from .base import BaseMatcher
+from .base import BaseMatcher, ExistsMatcher
 
 from urllib.parse import parse_qs
 
@@ -41,3 +41,7 @@ class QueryMatcher(BaseMatcher):
 
         # Match query params
         return self.match_query(query, req_query)
+
+
+class QueryParameterExistsMatcher(ExistsMatcher):
+    request_attr = "query"

--- a/src/pook/mock.py
+++ b/src/pook/mock.py
@@ -1,4 +1,3 @@
-import re
 import functools
 from furl import furl
 from inspect import isfunction, ismethod
@@ -276,10 +275,7 @@ class Mock(object):
             (pook.get('server.com/api')
                 .header_present('content-type'))
         """
-        for name in names:
-            headers = {name: re.compile("(.*)")}
-            self.add_matcher(matcher("HeadersMatcher", headers))
-        return self
+        return self.headers_present(names)
 
     def headers_present(self, headers):
         """
@@ -300,8 +296,11 @@ class Mock(object):
             (pook.get('server.com/api')
                 .headers_present(['content-type', 'Authorization']))
         """
-        headers = {name: re.compile("(.*)") for name in headers}
-        self.add_matcher(matcher("HeadersMatcher", headers))
+        if not headers:
+            raise ValueError("`headers` must not be empty")
+
+        for header in headers:
+            self.add_matcher(matcher("HeaderExistsMatcher", header))
         return self
 
     def type(self, value):
@@ -378,7 +377,7 @@ class Mock(object):
         Returns:
             self: current Mock instance.
         """
-        self.params({name: re.compile("(.*)")})
+        self.add_matcher(matcher("QueryParameterExistsMatcher", name))
         return self
 
     def params(self, params):

--- a/src/pook/mock.py
+++ b/src/pook/mock.py
@@ -367,17 +367,18 @@ class Mock(object):
         self.params({name: value})
         return self
 
-    def param_exists(self, name):
+    def param_exists(self, name, allow_empty=False):
         """
         Checks if a given URL param name is present in the URL.
 
         Arguments:
             name (str): param name to check existence.
+            allow_empty (bool): whether to allow an empty value of the param
 
         Returns:
             self: current Mock instance.
         """
-        self.add_matcher(matcher("QueryParameterExistsMatcher", name))
+        self.add_matcher(matcher("QueryParameterExistsMatcher", name, allow_empty))
         return self
 
     def params(self, params):

--- a/src/pook/request.py
+++ b/src/pook/request.py
@@ -90,10 +90,15 @@ class Request(object):
             if not protoregex.match(url):
                 url = "http://{}".format(url)
             self._url = urlparse(url)
-            self._query = parse_qs(self._url.query) if self._url.query else self._query
+            # keep_blank_values necessary for `param_exists` when a parameter has no value but is present
+            self._query = (
+                parse_qs(self._url.query, keep_blank_values=True)
+                if self._url.query
+                else self._query
+            )
 
     @property
-    def query(self, url):
+    def query(self):
         return self._query
 
     @query.setter

--- a/tests/unit/matchers/headers_test.py
+++ b/tests/unit/matchers/headers_test.py
@@ -236,6 +236,6 @@ def test_headers_present(required_headers, requested_headers, should_match):
     assert matched == should_match, explanation
 
 
-def test_headers_present_empty_headers():
+def test_headers_present_empty_argument():
     with pytest.raises(ValueError):
         pook.get("https://example.com").headers_present([])

--- a/tests/unit/matchers/query_test.py
+++ b/tests/unit/matchers/query_test.py
@@ -1,0 +1,21 @@
+import pytest
+from urllib.request import urlopen
+
+import pook
+from pook.exceptions import PookNoMatches
+
+
+@pytest.mark.pook(allow_pending_mocks=True)
+def test_param_exists_empty_disallowed():
+    pook.get("https://httpbin.org/404").param_exists("x").reply(200)
+
+    with pytest.raises(PookNoMatches):
+        urlopen("https://httpbin.org/404?x")
+
+
+@pytest.mark.pook
+def test_param_exists_empty_allowed():
+    pook.get("https://httpbin.org/404").param_exists("x", allow_empty=True).reply(200)
+
+    res = urlopen("https://httpbin.org/404?x")
+    assert res.status == 200

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -37,12 +37,11 @@ def test_mock_url(mock):
         pytest.param(
             {"param_exists": "z"},
             "?z",
+            marks=pytest.mark.xfail(
+                condition=True,
+                reason="Constructor does not have a method for passing `allow_empty` to `param_exists`",
+            ),
             id="param_exists_empty_on_request",
-        ),
-        pytest.param(
-            {"param_exists": "z"},
-            "?z=",
-            id="param_exists_empty_on_request_with_=",
         ),
         pytest.param(
             {"param_exists": "z"},

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -1,12 +1,10 @@
 import pytest
 import json
-import re
 
 import pook
 from pook.mock import Mock
 from pook.request import Request
 from urllib.request import urlopen
-from urllib.parse import urlencode
 
 
 @pytest.fixture
@@ -38,14 +36,22 @@ def test_mock_url(mock):
         ),
         pytest.param(
             {"param_exists": "z"},
-            # This complexity is needed until https://github.com/h2non/pook/issues/110
-            # is resolved
-            f'?{urlencode({"z": re.compile("(.*)")})}',
-            id="param_exists",
+            "?z",
+            id="param_exists_empty_on_request",
+        ),
+        pytest.param(
+            {"param_exists": "z"},
+            "?z=",
+            id="param_exists_empty_on_request_with_=",
+        ),
+        pytest.param(
+            {"param_exists": "z"},
+            "?z=123",
+            id="param_exists_has_value",
         ),
     ),
 )
-def test_constructor(param_kwargs, query_string):
+def test_mock_constructor(param_kwargs, query_string):
     # Should not raise
     mock = Mock(
         url="https://httpbin.org/404",
@@ -54,12 +60,9 @@ def test_constructor(param_kwargs, query_string):
         **param_kwargs,
     )
 
-    expected_url = f"https://httpbin.org/404{query_string}"
-    assert mock._request.rawurl == expected_url
-
     with pook.use():
         pook.engine().add_mock(mock)
-        res = urlopen(expected_url)
+        res = urlopen(f"https://httpbin.org/404{query_string}")
         assert res.status == 200
         assert json.loads(res.read()) == {"hello": "from pook"}
 


### PR DESCRIPTION
Fixes #110.

This PR simplifies the header and query param existence matches by introducing a new base matcher class, `ExistsMatcher`. Two new matcher classes, `HeaderExistsMatcher` and `QueryParameterExistsMatcher` are also introduced and the existing `header(s)_present` and `param_exists` methods are updated to use these matchers.

This removes the need to use the catch-all regexes for the value-check of the existence matchers. The new query-parameter existence matcher can be configured to allow empty values, which fixes #110 while preserving the existing behaviour of requiring _some_ value for the matcher's default behaviour. This prevents breaking backwards compatibility in the default behaviour. Setting `allow_empty=True` makes it possible to successfully match requests like `https://example.com/?refresh` where `refresh` is interpreted as true by the requested API if it is present and false if it is missing or if it is explicitly set to false (`refresh=false`). Here is a real-world example of such a parameter in a widely used API: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html#docs-reindex-api-query-params.

This backwards compatibility consideration does not effect headers, for whose existence matcher already allowed empty values in all cases because headers were never ignored due to their empty value.