### PR TITLE
fix #122: httpx streaming via `iter_raw` raises `httpx.StreamConsumed`

### DIFF
--- a/src/pook/interceptors/_httpx.py
+++ b/src/pook/interceptors/_httpx.py
@@ -75,6 +75,12 @@ class MockedTransport(httpx.BaseTransport):
             request=httpx_request,
         )
 
+        # Allow to read the response on client side
+        res.is_stream_consumed = False
+        res.is_closed = False
+        if hasattr(res, "_content"):
+            del res._content
+
         return res
 
 

--- a/tests/unit/interceptors/httpx_test.py
+++ b/tests/unit/interceptors/httpx_test.py
@@ -44,15 +44,23 @@ def test_json():
     assert response.json() == {"title": "123abc title"}
 
 
-def test_streaming():
+def _check_streaming_via(response_method):
     streamed_response = b"streamed response"
     pook.get(URL).times(1).reply(200).body(streamed_response).mock
 
     with httpx.stream("GET", URL) as r:
-        read_bytes = list(r.iter_bytes(chunk_size=1))
+        read_bytes = list(getattr(r, response_method)(chunk_size=1))
 
     assert len(read_bytes) == len(streamed_response)
     assert bytes().join(read_bytes) == streamed_response
+
+
+def test_streaming_via_iter_bytes():
+    _check_streaming_via("iter_bytes")
+
+
+def test_streaming_via_iter_raw():
+    _check_streaming_via("iter_raw")
 
 
 def test_redirect_following():


### PR DESCRIPTION
Closes #122.

Credit where credit's due, as was the case of https://github.com/h2non/pook/pull/91 this PR is also inspired by work done in https://github.com/Colin-b/pytest_httpx, the proposed fix corresponding to https://github.com/Colin-b/pytest_httpx/blob/b91bae4ec02a35e692700356dfe3753a20e32fc8/pytest_httpx/_httpx_mock.py#L269-L275