### PR TITLE
Expose expired mocks that would otherwise match the request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ extra-dependencies = [
     "urllib3~=1.24",
     "httpx~=0.26.0",
 
-    # aiohttp depends on multidict, so we can't test aiohttp until
-    # https://github.com/aio-libs/multidict/issues/887 is resolved
-    # async-timeout is only used for testing aiohttp
     "aiohttp~=3.8",
     "async-timeout~=4.0.3",
 

--- a/src/pook/engine.py
+++ b/src/pook/engine.py
@@ -438,7 +438,11 @@ class Engine(object):
                     msg += "\n\n=> Detailed matching errors:\n{}\n".format(err)
 
             # Raise no matches exception
-            raise PookNoMatches(msg)
+            self.no_matches(msg)
 
         # Register unmatched request
         self.unmatched_reqs.append(request)
+
+    def no_matches(self, msg):
+        """Raise `PookNoMatches` and reduce pytest printed stacktrace noise"""
+        raise PookNoMatches(msg)

--- a/src/pook/engine.py
+++ b/src/pook/engine.py
@@ -3,7 +3,7 @@ from inspect import isfunction
 from .mock import Mock
 from .regex import isregex
 from .mock_engine import MockEngine
-from .exceptions import PookNoMatches, PookExpiredMock
+from .exceptions import PookNoMatches
 
 
 class Engine(object):
@@ -416,16 +416,12 @@ class Engine(object):
 
         # Try to match the request against registered mock definitions
         for mock in self.mocks[:]:
-            try:
-                # Return the first matched HTTP request mock
-                matches, errors = mock.match(request.copy())
-                if len(errors):
-                    match_errors += errors
-                if matches:
-                    return mock
-            except PookExpiredMock:
-                # Remove the mock if already expired
-                self.mocks.remove(mock)
+            # Return the first matched HTTP request mock
+            matches, errors = mock.match(request.copy())
+            if len(errors):
+                match_errors += errors
+            if matches:
+                return mock
 
         # Validate that we have a mock
         if not self.should_use_network(request):

--- a/src/pook/exceptions.py
+++ b/src/pook/exceptions.py
@@ -15,7 +15,11 @@ class PookNetworkFilterError(Exception):
 
 class PookExpiredMock(Exception):
     def __init__(self, *args, **kwargs):
-        warnings.warn("PookExpiredMock is deprecated and will be removed in a future version of Pook", DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "PookExpiredMock is deprecated and will be removed in a future version of Pook",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(*args, **kwargs)
 
 

--- a/src/pook/exceptions.py
+++ b/src/pook/exceptions.py
@@ -1,3 +1,6 @@
+import warnings
+
+
 class PookInvalidBody(Exception):
     pass
 
@@ -11,7 +14,9 @@ class PookNetworkFilterError(Exception):
 
 
 class PookExpiredMock(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        warnings.warn("PookExpiredMock is deprecated and will be removed in a future version of Pook", DeprecationWarning, stacklevel=2)
+        super().__init__(*args, **kwargs)
 
 
 class PookInvalidArgument(Exception):

--- a/src/pook/matcher.py
+++ b/src/pook/matcher.py
@@ -29,7 +29,7 @@ class MatcherEngine(list):
             request (pook.Request): outgoing request to match.
 
         Returns:
-            tuple(bool, list[Exception]): ``True`` if all matcher tests
+            tuple(bool, list[str]): ``True`` if all matcher tests
                 passes, otherwise ``False``. Also returns an optional list
                 of error exceptions.
         """

--- a/src/pook/mock.py
+++ b/src/pook/mock.py
@@ -767,7 +767,7 @@ class Mock(object):
         if not matches:
             return False, errors
 
-        if self.isdone():
+        if self._times <= 0:
             return False, [f"Mock matches request but is expired.\n{repr(self)}"]
 
         # Register matched request for further inspecion and reference

--- a/src/pook/mock.py
+++ b/src/pook/mock.py
@@ -7,7 +7,6 @@ from .constants import TYPES
 from .request import Request
 from .matcher import MatcherEngine
 from .helpers import trigger_methods
-from .exceptions import PookExpiredMock
 from .matchers import init as matcher
 
 
@@ -750,10 +749,6 @@ class Mock(object):
                 the outgoing HTTP request, otherwise ``False``. Also returns
                 an optional list of error exceptions.
         """
-        # If mock already expired, fail it
-        if self._times <= 0:
-            raise PookExpiredMock("Mock expired")
-
         # Trigger mock filters
         for test in self.filters:
             if not test(request, self):
@@ -771,6 +766,11 @@ class Mock(object):
         # If not matched, return False
         if not matches:
             return False, errors
+
+        if self.isdone():
+            return False, [
+                f"Mock matches request but is expired.\n{repr(self)}"
+            ]
 
         # Register matched request for further inspecion and reference
         self._calls.append(request)

--- a/src/pook/mock.py
+++ b/src/pook/mock.py
@@ -768,9 +768,7 @@ class Mock(object):
             return False, errors
 
         if self.isdone():
-            return False, [
-                f"Mock matches request but is expired.\n{repr(self)}"
-            ]
+            return False, [f"Mock matches request but is expired.\n{repr(self)}"]
 
         # Register matched request for further inspecion and reference
         self._calls.append(request)

--- a/src/pook/regex.py
+++ b/src/pook/regex.py
@@ -1,10 +1,7 @@
 import re
 import sys
 
-if sys.version_info < (3, 7):
-    Pattern = type(re.compile(""))
-else:
-    Pattern = re.Pattern
+Pattern = re.Pattern
 
 
 def isregex_expr(expr):

--- a/src/pook/regex.py
+++ b/src/pook/regex.py
@@ -1,5 +1,4 @@
 import re
-import sys
 
 Pattern = re.Pattern
 

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -15,12 +15,6 @@ if platform.python_implementation() == "PyPy":
     examples.remove("mocket_example.py")
 
 
-if sys.version_info >= (3, 12):
-    # See pyproject.toml note on aiohttp dependency
-    examples.remove("aiohttp_client.py")
-    examples.remove("decorator_activate_async.py")
-
-
 @pytest.mark.parametrize("example", examples)
 def test_examples(example):
     result = subprocess.run(["python", "examples/{}".format(example)])

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -1,4 +1,3 @@
-import sys
 import subprocess
 import pytest
 from pathlib import Path

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -4,6 +4,5 @@ from pook import exceptions as ex
 def test_exceptions():
     assert isinstance(ex.PookNoMatches(), Exception)
     assert isinstance(ex.PookInvalidBody(), Exception)
-    assert isinstance(ex.PookExpiredMock(), Exception)
     assert isinstance(ex.PookNetworkFilterError(), Exception)
     assert isinstance(ex.PookInvalidArgument(), Exception)

--- a/tests/unit/mock_test.py
+++ b/tests/unit/mock_test.py
@@ -135,7 +135,11 @@ def test_times(mock):
 
     assert mock.match(req) == (True, [])
     assert mock.match(req) == (True, [])
-    assert mock.match(req) == (False, ["ExpiredMatcher: Mock is expired"])
+    matches, errors = mock.match(req)
+    assert not matches
+    assert len(errors) == 1
+    assert "Mock matches request but is expired." in errors[0]
+    assert repr(mock) in errors[0]
 
 
 @pytest.mark.pook


### PR DESCRIPTION
Closes #127 by @silverwind

Thanks for the idea! If you have time to check out this PR and see if it matches what you had in mind, please do. Here's an example from a test case to demonstrate how this looks in practice:

```
__________________________________________________________________________________________ test_times_integrated ___________________________________________________________________________________________

httpbin = <pytest_httpbin.serve.Server object at 0x73b353b25640>

    @pytest.mark.pook
    def test_times_integrated(httpbin):
        url = f"{httpbin.url}/status/404"
        pook.get(url).times(2).reply(200).body("hello from pook")
    
        res = urlopen(url)
        assert res.read() == "hello from pook"
    
        res = urlopen(url)
        assert res.read() == "hello from pook"
    
        # with pytest.raises(PookNoMatches, match="Mock matches request but is expired."):
>       urlopen(url)

tests/unit/mock_test.py:153: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../.local/share/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/urllib/request.py:215: in urlopen
    return opener.open(url, data, timeout)
../../.local/share/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/urllib/request.py:515: in open
    response = self._open(req, data)
../../.local/share/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/urllib/request.py:532: in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
../../.local/share/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/urllib/request.py:492: in _call_chain
    result = func(*args)
../../.local/share/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/urllib/request.py:1373: in http_open
    return self.do_open(http.client.HTTPConnection, req)
../../.local/share/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/urllib/request.py:1344: in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
src/pook/interceptors/http.py:112: in handler
    return self._on_request(
src/pook/interceptors/http.py:61: in _on_request
    mock = self.engine.match(req)
src/pook/engine.py:441: in match
    self.no_matches(msg)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pook.engine.Engine object at 0x73b35303d7f0>
msg = 'pook error!\n\n=> Cannot match any mock for the following request:\n=================================================...04)\n  ]),\n  response=Response(\n    headers=HTTPHeaderDict({}),\n    status=200,\n    body=hello from pook\n  )\n)\n'

    def no_matches(self, msg):
>       raise PookNoMatches(msg)
E       pook.exceptions.PookNoMatches: pook error!
E       
E       => Cannot match any mock for the following request:
E       ==================================================
E       Method: GET
E       URL: http://127.0.0.1:40529/status/404
E       Headers: HTTPHeaderDict({'Host': '127.0.0.1:40529', 'User-Agent': 'Python-urllib/3.12', 'Connection': 'close'})
E       ==================================================
E       
E       => Detailed matching errors:
E       Mock matches request but is expired.
E       Mock(
E         matches=2,
E         times=0,
E         persist=False,
E         matchers=MatcherEngine([
E           MethodMatcher(GET),
E           URLMatcher(http://127.0.0.1:40529/status/404)
E         ]),
E         response=Response(
E           headers=HTTPHeaderDict({}),
E           status=200,
E           body=hello from pook
E         )
E       )
```

