### PR TITLE
Add a pytest fixture for pook

### DIFF
--- a/History.rst
+++ b/History.rst
@@ -33,6 +33,8 @@ Draft v2.0.0 / Unreleased
 
     * These classes never implemented regex matching
 
+  * Add a pytest fixture to the package.
+
 v1.4.3 / 2024-02-23
 -------------------
 

--- a/examples/pytest_example.py
+++ b/examples/pytest_example.py
@@ -36,3 +36,9 @@ def test_no_match_exception():
     pook.get("server.com/bar", reply=204)
     with pytest.raises(Exception):
         requests.get("http://server.com/baz")
+
+
+def test_fixture(pook):
+    pook.get("https://example.org/").reply(204)
+    res = requests.get("https://example.org/")
+    assert res.status_code == 204

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ requires-python = ">=3.8"
 [project.urls]
 Homepage = "https://github.com/h2non/pook"
 
+[project.entry-points.pytest11]
+pook = "pook.pytest_fixture"
+
 [tool.hatch.version]
 path = "src/pook/__init__.py"
 

--- a/src/pook/pytest_fixture.py
+++ b/src/pook/pytest_fixture.py
@@ -1,0 +1,11 @@
+import pytest
+
+import pook as pook_mod
+
+
+@pytest.fixture
+def pook():
+    """Pytest fixture for HTTP traffic mocking and testing"""
+    pook_mod.on()
+    yield pook_mod
+    pook_mod.off()

--- a/src/pook/pytest_fixture.py
+++ b/src/pook/pytest_fixture.py
@@ -6,6 +6,5 @@ import pook as pook_mod
 @pytest.fixture
 def pook():
     """Pytest fixture for HTTP traffic mocking and testing"""
-    pook_mod.on()
-    yield pook_mod
-    pook_mod.off()
+    with pook_mod.use():
+        yield pook_mod


### PR DESCRIPTION
I've been copy-pasting this simple fixture around in several project's `conftest.py` files for years now. I've seen the recent `pytest-pook` plugin on PyPI/sourcehut, but it doesn't actually have what is the most pytest-thonic usage, simply with a fixture and not needing to import the pook module from your test code at all:

```
def test_something(pook):
    pook.get("https://example.org/").reply(204)
    res = requests.get("https://example.org/")
    assert res.status_code == 204
```

And I see no reason why this entrypoint couldn't just go into `pook` directly, rather than an extra package. It needn't create a pytest dependency because the submodule `pytest_fixture.py` is not imported except by pytest configure.

Let me know what you think!