### PR TITLE
Improve aiohttp JSONMatcher support

### DIFF
--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -1,5 +1,3 @@
-import json
-
 from ..request import Request
 from .base import BaseInterceptor
 
@@ -81,8 +79,8 @@ class AIOHTTPInterceptor(BaseInterceptor):
             )
 
         # If a json payload is provided, serialize it for JSONMatcher support
-        if kw.get("json"):
-            req.body = json.dumps(kw["json"])
+        if json_body := kw.get("json"):
+            req.json = json_body
             if "Content-Type" not in req.headers:
                 req.headers["Content-Type"] = "application/json"
 

--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -1,3 +1,5 @@
+import json
+
 from ..request import Request
 from .base import BaseInterceptor
 
@@ -77,6 +79,12 @@ class AIOHTTPInterceptor(BaseInterceptor):
             req.url = (
                 str(url) + "?" + urlencode([(x, y) for x, y in kw["params"].items()])
             )
+
+        # If a json payload is provided, serialize it for JSONMatcher support
+        if kw.get("json"):
+            req.body = json.dumps(kw["json"])
+            if "Content-Type" not in req.headers:
+                req.headers["Content-Type"] = "application/json"
 
         # Match the request against the registered mocks in pook
         mock = self.engine.match(req)

--- a/tests/unit/interceptors/aiohttp_test.py
+++ b/tests/unit/interceptors/aiohttp_test.py
@@ -1,5 +1,6 @@
 import pytest
 import aiohttp
+import json
 
 import pook
 
@@ -54,4 +55,22 @@ async def test_binary_body(URL):
     pook.get(URL).reply(200).body(BINARY_FILE)
     async with aiohttp.ClientSession() as session:
         req = await session.get(URL)
+        assert await req.read() == BINARY_FILE
+
+
+@pytest.mark.asyncio
+async def test_json_matcher_data_payload(URL):
+    payload={'foo': 'bar'}
+    pook.post(URL).json(payload).reply(200).body(BINARY_FILE)
+    async with aiohttp.ClientSession() as session:
+        req = await session.post(URL, data=json.dumps(payload))
+        assert await req.read() == BINARY_FILE
+
+
+@pytest.mark.asyncio
+async def test_json_matcher_json_payload(URL):
+    payload={'foo': 'bar'}
+    pook.post(URL).json(payload).reply(200).body(BINARY_FILE)
+    async with aiohttp.ClientSession() as session:
+        req = await session.post(URL, json=payload)
         assert await req.read() == BINARY_FILE

--- a/tests/unit/interceptors/aiohttp_test.py
+++ b/tests/unit/interceptors/aiohttp_test.py
@@ -60,7 +60,7 @@ async def test_binary_body(URL):
 
 @pytest.mark.asyncio
 async def test_json_matcher_data_payload(URL):
-    payload={'foo': 'bar'}
+    payload = {"foo": "bar"}
     pook.post(URL).json(payload).reply(200).body(BINARY_FILE)
     async with aiohttp.ClientSession() as session:
         req = await session.post(URL, data=json.dumps(payload))
@@ -69,7 +69,7 @@ async def test_json_matcher_data_payload(URL):
 
 @pytest.mark.asyncio
 async def test_json_matcher_json_payload(URL):
-    payload={'foo': 'bar'}
+    payload = {"foo": "bar"}
     pook.post(URL).json(payload).reply(200).body(BINARY_FILE)
     async with aiohttp.ClientSession() as session:
         req = await session.post(URL, json=payload)


### PR DESCRIPTION
The current implementation of the `aiohttp` interceptor does not account for using the `json` argument.

Before this PR you would get the following error when using the `json` param from aiohttp
with the JSONMatcher:
```
    def no_matches(self, msg):
        """Raise `PookNoMatches` and reduce pytest printed stacktrace noise"""
>       raise PookNoMatches(msg)
E       pook.exceptions.PookNoMatches: pook error!
E       
E       => Cannot match any mock for the following request:
E       ==================================================
E       Method: POST
E       URL: http://example.com
E       ==================================================
E       
E       => Detailed matching errors:
E       JSONMatcher: 'NoneType' object has no attribute 'decode'
```