### PR TITLE
Add baseline for types

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -32,7 +32,7 @@ jobs:
         run: pipx install hatch
 
       - name: Lint
-        run: hatch run lint:run
+        run: hatch run lint
 
   build:
     name: build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,11 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: types
+        name: types
+        entry: hatch run types
+        language: system
+        pass_filenames: false

--- a/README.rst
+++ b/README.rst
@@ -261,14 +261,14 @@ Install the pre-commit hook:
 
 .. code:: bash
 
-    hatch run lint:install
+    hatch run lint-install
 
 
 Lint the code:
 
 .. code:: bash
 
-    hatch run lint:run
+    hatch run lint
 
 
 Run tests on all supported Python versions and implementations (this requires your host operating system to have each implementation available):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,13 @@ packages = ["src/pook"]
 [tool.hatch.envs.default]
 python = "3.12"
 extra-dependencies = [
+    "pre-commit~=4.0",
+    "mypy>=1.11.2",
+
     "pytest~=8.3",
     "pytest-asyncio~=0.24",
     "pytest-pook==0.1.0b0",
     "pytest-httpbin==2.1.0",
-    "mypy>=1.11.2",
 
     "requests~=2.20",
     "urllib3~=2.2",
@@ -73,14 +75,8 @@ extra-dependencies = [
 test = "pytest {args}"
 types = "mypy --install-types --non-interactive src/pook/interceptors {args}"
 
-[tool.hatch.envs.lint]
-extra-dependencies = [
-    "pre-commit~=4.0",
-]
-
-[tool.hatch.envs.lint.scripts]
-install = 'pre-commit install'
-run = 'pre-commit run --all-files'
+lint-install = "pre-commit install"
+lint = "pre-commit run --all-files"
 
 [tool.hatch.envs.docs]
 extra-dependencies = [
@@ -89,9 +85,9 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.docs.scripts]
-apidocs = 'sphinx-apidoc -f --follow-links -H "API documentation" -o docs/source src/pook'
-htmldocs = 'rm -rf docs/_build && sphinx-build -b html -d docs/_build/doctrees ./docs docs/_build/html'
-build = 'hatch run apidocs; hatch run htmldocs'
+apidocs = "sphinx-apidoc -f --follow-links -H 'API documentation' -o docs/source src/pook"
+htmldocs = "rm -rf docs/_build && sphinx-build -b html -d docs/_build/doctrees ./docs docs/_build/html"
+build = "hatch run apidocs; hatch run htmldocs"
 
 [tool.hatch.envs.test]
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,12 @@ packages = ["src/pook"]
 
 [tool.hatch.envs.default]
 python = "3.12"
-scripts = { test = 'pytest {args}' }
 extra-dependencies = [
     "pytest~=8.3",
     "pytest-asyncio~=0.24",
     "pytest-pook==0.1.0b0",
     "pytest-httpbin==2.1.0",
+    "mypy>=1.11.2",
 
     "requests~=2.20",
     "urllib3~=2.2",
@@ -68,6 +68,10 @@ extra-dependencies = [
     # mocket relies on httptools which does not support PyPy
     "mocket[pook]~=3.12.2; platform_python_implementation != 'PyPy'",
 ]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args}"
+types = "mypy --install-types --non-interactive src/pook/interceptors {args}"
 
 [tool.hatch.envs.lint]
 extra-dependencies = [

--- a/src/pook/__init__.py
+++ b/src/pook/__init__.py
@@ -1,8 +1,43 @@
-from .api import *  # noqa
-from .api import __all__ as api_exports
+from .api import *  # noqa: F403
 
 # Delegate to API export
-__all__ = api_exports
+__all__ = (
+    "activate",  # noqa: F405
+    "on",  # noqa: F405
+    "disable",  # noqa: F405
+    "off",  # noqa: F405
+    "reset",  # noqa: F405
+    "engine",  # noqa: F405
+    "use_network",  # noqa: F405
+    "enable_network",  # noqa: F405
+    "disable_network",  # noqa: F405
+    "get",  # noqa: F405
+    "post",  # noqa: F405
+    "put",  # noqa: F405
+    "patch",  # noqa: F405
+    "head",  # noqa: F405
+    "use",  # noqa: F405
+    "set_mock_engine",  # noqa: F405
+    "delete",  # noqa: F405
+    "options",  # noqa: F405
+    "pending",  # noqa: F405
+    "ispending",  # noqa: F405
+    "mock",  # noqa: F405
+    "pending_mocks",  # noqa: F405
+    "unmatched_requests",  # noqa: F405
+    "isunmatched",  # noqa: F405
+    "unmatched",  # noqa: F405
+    "isactive",  # noqa: F405
+    "isdone",  # noqa: F405
+    "regex",  # noqa: F405
+    "Engine",  # noqa: F405
+    "Mock",  # noqa: F405
+    "Request",  # noqa: F405
+    "Response",  # noqa: F405
+    "MatcherEngine",  # noqa: F405
+    "MockEngine",  # noqa: F405
+    "use_network_filter",  # noqa: F405
+)
 
 # Package metadata
 __author__ = "Tomas Aparicio"

--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -6,15 +6,12 @@ from urllib.parse import urlencode, urlunparse
 from aiohttp.helpers import TimerNoop
 from aiohttp.streams import EmptyStreamReader
 
-from ..request import Request
-from .base import BaseInterceptor
+from pook.request import Request  # type: ignore
+from pook.interceptors.base import BaseInterceptor
 
 # Try to load yarl URL parser package used by aiohttp
-try:
-    import multidict
-    import yarl
-except Exception:
-    yarl, multidict = None, None
+import multidict
+import yarl
 
 PATCHES = ("aiohttp.client.ClientSession._request",)
 

--- a/src/pook/interceptors/http.py
+++ b/src/pook/interceptors/http.py
@@ -1,15 +1,14 @@
 import socket
-from http.client import (
-    _CS_REQ_SENT,
-    HTTPSConnection,
-)
+from http.client import _CS_REQ_SENT  # type: ignore[attr-defined]
+from http.client import HTTPSConnection
+
 from http.client import (
     responses as http_reasons,
 )
 from unittest import mock
 
-from ..request import Request
-from .base import BaseInterceptor
+from pook.request import Request  # type: ignore
+from pook.interceptors.base import BaseInterceptor
 
 PATCHES = ("http.client.HTTPConnection.request",)
 
@@ -88,8 +87,8 @@ class HTTPClientInterceptor(BaseInterceptor):
 
         conn.getresponse = getresponse
 
-        conn.__response = mockres
-        conn.__state = _CS_REQ_SENT
+        conn.__response = mockres  # type: ignore[attr-defined]
+        conn.__state = _CS_REQ_SENT  # type: ignore[attr-defined]
 
         # Path reader
         def read():

--- a/src/pook/interceptors/urllib3.py
+++ b/src/pook/interceptors/urllib3.py
@@ -7,9 +7,9 @@ from http.client import (
 )
 from unittest import mock
 
-from ..request import Request
-from .base import BaseInterceptor
-from .http import URLLIB3_BYPASS
+from pook.request import Request  # type: ignore
+from pook.interceptors.base import BaseInterceptor
+from pook.interceptors.http import URLLIB3_BYPASS
 
 PATCHES = (
     "requests.packages.urllib3.connectionpool.HTTPConnectionPool.urlopen",
@@ -28,7 +28,7 @@ def HTTPResponse(path, *args, **kw):
     # Infer package
     package = path.split(".").pop(0)
     # Get import path
-    import_path = RESPONSE_PATH.get(package)
+    import_path = RESPONSE_PATH[package]
 
     # Dynamically load package
     module = __import__(import_path, fromlist=(RESPONSE_CLASS,))
@@ -148,8 +148,8 @@ class Urllib3Interceptor(BaseInterceptor):
         if is_chunked_response(headers):
             body_chunks = body if isinstance(body, list) else [body]
 
-            body = ClientHTTPResponse(MockSock)
-            body.fp = FakeChunkedResponseBody(body_chunks)
+            body = ClientHTTPResponse(MockSock)  # type: ignore
+            body.fp = FakeChunkedResponseBody(body_chunks)  # type:ignore
         else:
             # Assume that the body is a bytes-like object
             body = io.BytesIO(res._body)

--- a/src/pook/request.py
+++ b/src/pook/request.py
@@ -77,10 +77,6 @@ class Request:
     def url(self):
         return self._url
 
-    @property
-    def rawurl(self):
-        return self._url if isregex(self._url) else urlunparse(self._url)
-
     @url.setter
     def url(self, url):
         if isregex(url):
@@ -95,6 +91,10 @@ class Request:
                 if self._url.query
                 else self._query
             )
+
+    @property
+    def rawurl(self):
+        return self._url if isregex(self._url) else urlunparse(self._url)
 
     @property
     def query(self):


### PR DESCRIPTION
This PR adds mypy and baseline type-checking infrastructure to CI and the project's scripts.

For this PR, type checking is restricted to the interceptors, and follow-up PRs can add annotations and checking to other files individually. I've done this to prevent the size of this PR from getting out of hand.

When adding annotations to a previously unannotated file, we'll add that file (or directory, if possible) to the `types` script's list of explicit places to check. After we've annotated all of `src/pook`, we can condense the list down to just that. Finally, we'll enable type checking for the tests.

Ideally, the addition of annotations does _not_ require introducing runtime code changes. At times, though, it seems like it will be, if the types are to be useful for Pook itself (rather than just on the surface for users). It's certainly better if the project itself has correct and useful annotations to rely on, rather than just API-surface level stubs. The reason for that are:

1. So that maintainers of pook get to benefit from the hints and help that type annotations add throughout the entire code. I've already seen some potentially incorrect code just from doing basic exploratory type annotating in the project. Those aren't in this PR, but will come up later, and would help the project maintain internal integrity.
2. So that we do not need to maintain separate type stubs which may go out of sync with the actual API surface of the module.