### PR TITLE
Fix aiohttp session match

### DIFF
--- a/History.rst
+++ b/History.rst
@@ -1,11 +1,14 @@
 History
 =======
 
-vX.Y.Z / 20xx-xx-xx
+v2.1.2 / 2024-11-21
 -------------------------
 
   * Return the correct type of ``headers`` object for standard library urllib by @sarayourfriend in https://github.com/h2non/pook/pull/154.
   * Support ``Sequence[tuple[str, str]]`` header input with aiohttp by @sarayourfriend in https://github.com/h2non/pook/pull/154.
+  * Fix network filters when multiple filters are active by @rsmeral in https://github.com/h2non/pook/pull/155.
+  * Fix aiohttp matching not working with session base URL or headers by @sarayourfriend in https://github.com/h2non/pook/pull/157.
+  * Add support for Python 3.13 by @sarayourfriend in https://github.com/h2non/pook/pull/149.
 
 v2.1.1 / 2024-10-15
 -------------------------

--- a/src/pook/__init__.py
+++ b/src/pook/__init__.py
@@ -44,4 +44,4 @@ __author__ = "Tomas Aparicio"
 __license__ = "MIT"
 
 # Current version
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -1,6 +1,7 @@
 import platform
 import subprocess
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -16,6 +17,6 @@ if platform.python_implementation() == "PyPy":
 
 @pytest.mark.parametrize("example", examples)
 def test_examples(example):
-    result = subprocess.run(["python", f"examples/{example}"], check=False)
+    result = subprocess.run([sys.executable, f"examples/{example}"], check=False)
 
     assert result.returncode == 0, result.stdout

--- a/tests/unit/interceptors/aiohttp_test.py
+++ b/tests/unit/interceptors/aiohttp_test.py
@@ -64,3 +64,25 @@ async def test_json_matcher_json_payload(URL):
     async with aiohttp.ClientSession() as session:
         req = await session.post(URL, json=payload)
         assert await req.read() == BINARY_FILE
+
+
+@pytest.mark.asyncio
+async def test_client_base_url(httpbin):
+    """Client base url should be matched."""
+    pook.get(httpbin + "/status/404").reply(200).body("hello from pook")
+    async with aiohttp.ClientSession(base_url=httpbin.url) as session:
+        res = await session.get("/status/404")
+        assert res.status == 200
+        assert await res.read() == b"hello from pook"
+
+
+@pytest.mark.asyncio
+async def test_client_headers(httpbin):
+    """Headers set on the client should be matched."""
+    pook.get(httpbin + "/status/404").header("x-pook", "hello").reply(200).body(
+        "hello from pook"
+    )
+    async with aiohttp.ClientSession(headers={"x-pook": "hello"}) as session:
+        res = await session.get(httpbin + "/status/404")
+        assert res.status == 200
+        assert await res.read() == b"hello from pook"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Fixes #XXX -->
Fixes #156 

Also fixed a few aiohttp edge cases:
- If the client session has a special response class set, pook will now use that for the mocked response.
- Pook now uses aiohttp's named tuple to set the `version` on the response rather than an anonymous tuple.

## PR Checklist

- [x] I've added tests for any code changes
- [x] I've documented any new features
