### PR TITLE
Ensure aiohttp headers matchable from both session and request

### DIFF
--- a/History.rst
+++ b/History.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+v2.1.3 / 2024-11-25
+-------------------------
+
+  * Ensure aiohttp headers can be matched from both the session and request in the same matcher
+
 v2.1.2 / 2024-11-21
 -------------------------
 

--- a/History.rst
+++ b/History.rst
@@ -1,7 +1,7 @@
 History
 =======
 
-v2.1.3 / 2024-11-25
+v2.1.3 / 2024-12-16
 -------------------------
 
   * Ensure aiohttp headers can be matched from both the session and request in the same matcher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.rst"
 license = "MIT"
 authors = [
     { name = "Tomas Aparicio", email = "tomas@aparicio.me" },
+    { name = "Sara Marcondes", email = "git@sarayourfriend.pictures" },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/pook/__init__.py
+++ b/src/pook/__init__.py
@@ -44,4 +44,4 @@ __author__ = "Tomas Aparicio"
 __license__ = "MIT"
 
 # Current version
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -58,18 +58,15 @@ class AIOHTTPInterceptor(BaseInterceptor):
         # ``pook.request`` only allows a dict, so we need to map the iterable to the matchable interface
         if headers:
             if isinstance(headers, Mapping):
-                req.headers = headers
+                req.headers.update(**headers)
             else:
-                req_headers: dict[str, str] = {}
                 # If it isn't a mapping, then its an Iterable[Tuple[Union[str, istr], str]]
                 for req_header, req_header_value in headers:
                     normalised_header = req_header.lower()
-                    if normalised_header in req_headers:
-                        req_headers[normalised_header] += f", {req_header_value}"
+                    if normalised_header in req.headers:
+                        req.headers[normalised_header] += f", {req_header_value}"
                     else:
-                        req_headers[normalised_header] = req_header_value
-
-                req.headers = req_headers
+                        req.headers[normalised_header] = req_header_value
 
     async def _on_request(
         self,

--- a/tests/unit/interceptors/aiohttp_test.py
+++ b/tests/unit/interceptors/aiohttp_test.py
@@ -86,3 +86,31 @@ async def test_client_headers(httpbin):
         res = await session.get(httpbin + "/status/404")
         assert res.status == 200
         assert await res.read() == b"hello from pook"
+
+
+@pytest.mark.asyncio
+async def test_client_headers_merged(httpbin):
+    """Headers set on the client should be matched even if request-specific headers are sent."""
+    pook.get(httpbin + "/status/404").header("x-pook", "hello").reply(200).body(
+        "hello from pook"
+    )
+    async with aiohttp.ClientSession(headers={"x-pook": "hello"}) as session:
+        res = await session.get(
+            httpbin + "/status/404", headers={"x-pook-secondary": "xyz"}
+        )
+        assert res.status == 200
+        assert await res.read() == b"hello from pook"
+
+
+@pytest.mark.asyncio
+async def test_client_headers_both_session_and_request(httpbin):
+    """Headers should be matchable from both the session and request in the same matcher"""
+    pook.get(httpbin + "/status/404").header("x-pook-session", "hello").header(
+        "x-pook-request", "hey"
+    ).reply(200).body("hello from pook")
+    async with aiohttp.ClientSession(headers={"x-pook-session": "hello"}) as session:
+        res = await session.get(
+            httpbin + "/status/404", headers={"x-pook-request": "hey"}
+        )
+        assert res.status == 200
+        assert await res.read() == b"hello from pook"

--- a/tests/unit/interceptors/base.py
+++ b/tests/unit/interceptors/base.py
@@ -208,7 +208,7 @@ class StandardTests:
         assert body == b"hello from pook"
 
     @pytest.mark.pook
-    def test_mocked_resposne_headers(self, url_404):
+    def test_mocked_response_headers(self, url_404):
         """Mocked response headers are appropriately returned."""
         pook.get(url_404).reply(200).header("x-hello", "from pook")
 
@@ -238,3 +238,11 @@ class StandardTests:
 
         assert status == 200
         assert headers["x-hello"] == "from pook, another time"
+
+    @pytest.mark.pook(allow_pending_mocks=True)
+    def test_unmatched_headers_none_sent(self, url_404):
+        """Header matching will run, but not match, on requests that send no headers."""
+        pook.get(url_404).header("x-hello", "from pook").reply(200)
+
+        with pytest.raises(PookNoMatches):
+            self.make_request("GET", url_404)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Fixes #XXX -->
Follow up to #156 and the PR #157. The code in that PR overrides the Pook request headers with any headers sent from the aiohttp request. If you tried to match on headers configured via the session and the request, only the request headers would be present on the Pook request.

## PR Checklist

- [x] I've added tests for any code changes
- [x] I've documented any new features
