### PR TITLE
Replace pytest-httpbin with minimal Falcon version

### DIFF
--- a/examples/regex.py
+++ b/examples/regex.py
@@ -7,7 +7,7 @@ pook.on()
 
 # Mock definition based
 (
-    pook.get(pook.regex("h[t]{2}pbin.*"))
+    pook.get(pook.regex("h[t]{2}p*"))
     .path(pook.regex("/foo/[a-z]+/baz"))
     .header("Client", pook.regex("requests|pook"))
     .times(2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ dependencies = [
     "pytest~=8.3",
     "pytest-asyncio~=0.24",
     "pytest-pook==0.1.0b0",
-    "pytest-httpbin==2.1.0",
+
+    "falcon~=4.0",
 
     "requests~=2.20",
     "urllib3~=2.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+from wsgiref.simple_server import make_server
+
+import falcon
+
+import threading
+
+import pytest
+
+
+class HttpbinLikeResource:
+    def on_get_status(self, req: falcon.Request, resp: falcon.Response, status: int):
+        resp.set_header("x-pook-httpbinlike", "")
+        resp.status = status
+
+    on_post_status = on_get_status
+
+
+class HttpbinLike:
+    def __init__(self, schema: str, host: str):
+        self.schema = schema
+        self.host = host
+        self.url = schema + host
+
+    def __add__(self, value):
+        return self.url + value
+
+
+@pytest.fixture(scope="session")
+def local_responder():
+    app = falcon.App()
+    resource = HttpbinLikeResource()
+    app.add_route("/status/{status:int}", resource, suffix="status")
+
+    with make_server("127.0.0.1", 8080, app) as httpd:
+
+        def run():
+            httpd.serve_forever()
+
+        thread = threading.Thread(target=run)
+        thread.start()
+        yield HttpbinLike("http://", "127.0.0.1:8080")
+        httpd.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def url_404(local_responder):
+    """404 httpbin URL.
+
+    Useful in tests if pook is configured to reply 200, and the status is checked.
+    If pook does not match the request (and if that was the intended behaviour)
+    then the 404 status code makes that obvious!"""
+    return local_responder + "/status/404"
+
+
+@pytest.fixture
+def url_401(local_responder):
+    return local_responder + "/status/401"
+
+
+@pytest.fixture
+def url_500(local_responder):
+    return local_responder + "/status/500"

--- a/tests/integration/engines/pytest_suite.py
+++ b/tests/integration/engines/pytest_suite.py
@@ -5,35 +5,39 @@ import pook
 
 
 @pook.on
-def test_simple_pook_request():
-    pook.get("httpbin.org/foo").reply(204)
-    res = requests.get("http://httpbin.org/foo")
+def test_simple_pook_request(url_404):
+    pook.get(url_404).reply(204)
+    res = requests.get(url_404)
     assert res.status_code == 204
 
 
 @pook.on
-def test_enable_engine():
-    pook.get("server.com/foo").reply(204)
-    res = requests.get("http://server.com/foo")
+def test_enable_engine(url_404):
+    pook.get(url_404).reply(204)
+    res = requests.get(url_404)
     assert res.status_code == 204
     pook.disable()
 
 
-@pook.get("server.com/bar", reply=204)
-def test_decorator():
-    res = requests.get("http://server.com/bar")
-    assert res.status_code == 204
+def test_decorator(url_404):
+    @pook.get(url_404, reply=204)
+    def do():
+        res = requests.get(url_404)
+        assert res.status_code == 204
+        return True
+
+    assert do()
 
 
-def test_context_manager():
+def test_context_manager(url_404):
     with pook.use():
-        pook.get("server.com/baz", reply=204)
-        res = requests.get("http://server.com/baz")
+        pook.get(url_404, reply=204)
+        res = requests.get(url_404)
         assert res.status_code == 204
 
 
 @pook.on
-def test_no_match_exception():
-    pook.get("server.com/bar", reply=204)
+def test_no_match_exception(url_404, url_401):
+    pook.get(url_404, reply=204)
     with pytest.raises(Exception):
-        requests.get("http://server.com/baz")
+        requests.get(url_401)

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -2,21 +2,32 @@ import platform
 import subprocess
 from pathlib import Path
 import sys
+import re
 
 import pytest
 
 examples_dir = Path(__file__).parents[2] / "examples"
 
-examples = [f.name for f in examples_dir.glob("*.py")]
+examples = list(examples_dir.glob("*.py"))
 
 
 if platform.python_implementation() == "PyPy":
     # See pyproject.toml note on mocket dependency
-    examples.remove("mocket_example.py")
+    examples.remove(examples_dir / "mocket_example.py")
 
 
-@pytest.mark.parametrize("example", examples)
-def test_examples(example):
-    result = subprocess.run([sys.executable, f"examples/{example}"], check=False)
+HTTPBIN_WITH_SCHEMA_REF = re.compile("https?://httpbin.org")
+
+
+@pytest.mark.parametrize(
+    "example", (pytest.param(example, id=example.name) for example in examples)
+)
+def test_examples(example: Path, local_responder):
+    code = example.read_text()
+    with_local_responder = HTTPBIN_WITH_SCHEMA_REF.sub(
+        local_responder.url, code
+    ).replace("httpbin.org", local_responder.host)
+    assert "httpbin" not in with_local_responder
+    result = subprocess.run([sys.executable, "-c", with_local_responder], check=False)
 
     assert result.returncode == 0, result.stdout

--- a/tests/unit/interceptors/aiohttp_test.py
+++ b/tests/unit/interceptors/aiohttp_test.py
@@ -20,97 +20,92 @@ class TestStandardAiohttp(StandardTests):
             return response.status, response_content, response.headers
 
 
-def _pook_url(URL):
-    return pook.head(URL).reply(200).mock
-
-
-@pytest.fixture
-def URL(httpbin):
-    return f"{httpbin.url}/status/404"
+def _pook_url(url):
+    return pook.head(url).reply(200).mock
 
 
 @pytest.mark.asyncio
-async def test_async_with_request(URL):
-    mock = _pook_url(URL)
+async def test_async_with_request(url_404):
+    mock = _pook_url(url_404)
     async with aiohttp.ClientSession() as session:
-        async with session.head(URL) as req:
+        async with session.head(url_404) as req:
             assert req.status == 200
 
     assert len(mock.matches) == 1
 
 
 @pytest.mark.asyncio
-async def test_await_request(URL):
-    mock = _pook_url(URL)
+async def test_await_request(url_404):
+    mock = _pook_url(url_404)
     async with aiohttp.ClientSession() as session:
-        req = await session.head(URL)
+        req = await session.head(url_404)
         assert req.status == 200
 
     assert len(mock.matches) == 1
 
 
 @pytest.mark.asyncio
-async def test_binary_body(URL):
-    pook.get(URL).reply(200).body(BINARY_FILE)
+async def test_binary_body(url_404):
+    pook.get(url_404).reply(200).body(BINARY_FILE)
     async with aiohttp.ClientSession() as session:
-        req = await session.get(URL)
+        req = await session.get(url_404)
         assert await req.read() == BINARY_FILE
 
 
 @pytest.mark.asyncio
-async def test_json_matcher_json_payload(URL):
+async def test_json_matcher_json_payload(url_404):
     payload = {"foo": "bar"}
-    pook.post(URL).json(payload).reply(200).body(BINARY_FILE)
+    pook.post(url_404).json(payload).reply(200).body(BINARY_FILE)
     async with aiohttp.ClientSession() as session:
-        req = await session.post(URL, json=payload)
+        req = await session.post(url_404, json=payload)
         assert await req.read() == BINARY_FILE
 
 
 @pytest.mark.asyncio
-async def test_client_base_url(httpbin):
+async def test_client_base_url(local_responder):
     """Client base url should be matched."""
-    pook.get(httpbin + "/status/404").reply(200).body("hello from pook")
-    async with aiohttp.ClientSession(base_url=httpbin.url) as session:
+    pook.get(local_responder + "/status/404").reply(200).body("hello from pook")
+    async with aiohttp.ClientSession(base_url=local_responder.url) as session:
         res = await session.get("/status/404")
         assert res.status == 200
         assert await res.read() == b"hello from pook"
 
 
 @pytest.mark.asyncio
-async def test_client_headers(httpbin):
+async def test_client_headers(local_responder):
     """Headers set on the client should be matched."""
-    pook.get(httpbin + "/status/404").header("x-pook", "hello").reply(200).body(
+    pook.get(local_responder + "/status/404").header("x-pook", "hello").reply(200).body(
         "hello from pook"
     )
     async with aiohttp.ClientSession(headers={"x-pook": "hello"}) as session:
-        res = await session.get(httpbin + "/status/404")
+        res = await session.get(local_responder + "/status/404")
         assert res.status == 200
         assert await res.read() == b"hello from pook"
 
 
 @pytest.mark.asyncio
-async def test_client_headers_merged(httpbin):
+async def test_client_headers_merged(local_responder):
     """Headers set on the client should be matched even if request-specific headers are sent."""
-    pook.get(httpbin + "/status/404").header("x-pook", "hello").reply(200).body(
+    pook.get(local_responder + "/status/404").header("x-pook", "hello").reply(200).body(
         "hello from pook"
     )
     async with aiohttp.ClientSession(headers={"x-pook": "hello"}) as session:
         res = await session.get(
-            httpbin + "/status/404", headers={"x-pook-secondary": "xyz"}
+            local_responder + "/status/404", headers={"x-pook-secondary": "xyz"}
         )
         assert res.status == 200
         assert await res.read() == b"hello from pook"
 
 
 @pytest.mark.asyncio
-async def test_client_headers_both_session_and_request(httpbin):
+async def test_client_headers_both_session_and_request(local_responder):
     """Headers should be matchable from both the session and request in the same matcher"""
-    pook.get(httpbin + "/status/404").header("x-pook-session", "hello").header(
+    pook.get(local_responder + "/status/404").header("x-pook-session", "hello").header(
         "x-pook-request", "hey"
     ).reply(200).body("hello from pook")
     async with aiohttp.ClientSession(headers={"x-pook-session": "hello"}) as session:
         res = await session.get(
-            httpbin + "/status/404", headers={"x-pook-request": "hey"}
+            local_responder + "/status/404", headers={"x-pook-request": "hey"}
         )
         assert res.status == 200
         assert await res.read() == b"hello from pook"

--- a/tests/unit/interceptors/base.py
+++ b/tests/unit/interceptors/base.py
@@ -47,23 +47,6 @@ class StandardTests:
         else:
             yield
 
-    @pytest.fixture
-    def url_404(self, httpbin):
-        """404 httpbin URL.
-
-        Useful in tests if pook is configured to reply 200, and the status is checked.
-        If pook does not match the request (and if that was the intended behaviour)
-        then the 404 status code makes that obvious!"""
-        return f"{httpbin.url}/status/404"
-
-    @pytest.fixture
-    def url_500(self, httpbin):
-        return f"{httpbin.url}/status/500"
-
-    @pytest.fixture
-    def url_401(self, httpbin):
-        return httpbin + "/status/401"
-
     @pytest.mark.pook
     def test_activate_deactivate(self, url_404):
         """Deactivating pook allows requests to go through."""

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -36,17 +36,12 @@ class TestStandardRequests(StandardTests):
         return response.status_code, response.content, response.headers
 
 
-@pytest.fixture
-def URL(httpbin):
-    return f"{httpbin.url}/foo"
-
-
 @pook.on
-def assert_chunked_response(URL, input_data, expected):
-    (pook.get(URL).reply(201).body(input_data, chunked=True))
+def assert_chunked_response(url_404, input_data, expected):
+    (pook.get(url_404).reply(201).body(input_data, chunked=True))
 
     http = urllib3.PoolManager()
-    r = http.request("GET", URL)
+    r = http.request("GET", url_404)
 
     assert r.status == 201
 
@@ -54,24 +49,24 @@ def assert_chunked_response(URL, input_data, expected):
     assert chunks == expected
 
 
-def test_chunked_response_list(URL):
-    assert_chunked_response(URL, ["a", "b", "c"], [b"a", b"b", b"c"])
+def test_chunked_response_list(url_404):
+    assert_chunked_response(url_404, ["a", "b", "c"], [b"a", b"b", b"c"])
 
 
-def test_chunked_response_str(URL):
-    assert_chunked_response(URL, "text", [b"text"])
+def test_chunked_response_str(url_404):
+    assert_chunked_response(url_404, "text", [b"text"])
 
 
-def test_chunked_response_byte(URL):
-    assert_chunked_response(URL, b"byteman", [b"byteman"])
+def test_chunked_response_byte(url_404):
+    assert_chunked_response(url_404, b"byteman", [b"byteman"])
 
 
-def test_chunked_response_empty(URL):
-    assert_chunked_response(URL, "", [])
+def test_chunked_response_empty(url_404):
+    assert_chunked_response(url_404, "", [])
 
 
-def test_chunked_response_contains_newline(URL):
-    assert_chunked_response(URL, "newline\r\n", [b"newline\r\n"])
+def test_chunked_response_contains_newline(url_404):
+    assert_chunked_response(url_404, "newline\r\n", [b"newline\r\n"])
 
 
 def test_activate_disable():
@@ -85,29 +80,29 @@ def test_activate_disable():
 
 
 @pook.on
-def test_binary_body(URL):
-    (pook.get(URL).reply(200).body(BINARY_FILE))
+def test_binary_body(url_404):
+    (pook.get(url_404).reply(200).body(BINARY_FILE))
 
     http = urllib3.PoolManager()
-    r = http.request("GET", URL)
+    r = http.request("GET", url_404)
 
     assert r.read() == BINARY_FILE
 
 
 @pook.on
-def test_binary_body_chunked(URL):
-    (pook.get(URL).reply(200).body(BINARY_FILE, chunked=True))
+def test_binary_body_chunked(url_404):
+    (pook.get(url_404).reply(200).body(BINARY_FILE, chunked=True))
 
     http = urllib3.PoolManager()
-    r = http.request("GET", URL)
+    r = http.request("GET", url_404)
 
     assert list(r.read_chunked()) == [BINARY_FILE]
 
 
 @pytest.mark.pook
-def test_post_with_headers(URL):
-    mock = pook.post(URL).header("k", "v").reply(200).mock
+def test_post_with_headers(url_404):
+    mock = pook.post(url_404).header("k", "v").reply(200).mock
     http = urllib3.PoolManager(headers={"k": "v"})
-    resp = http.request("POST", URL)
+    resp = http.request("POST", url_404)
     assert resp.status == 200
     assert len(mock.matches) == 1

--- a/tests/unit/matchers/query_test.py
+++ b/tests/unit/matchers/query_test.py
@@ -6,22 +6,17 @@ import pook
 from pook.exceptions import PookNoMatches
 
 
-@pytest.fixture
-def URL(httpbin):
-    return f"{httpbin.url}/status/404"
-
-
 @pytest.mark.pook(allow_pending_mocks=True)
-def test_param_exists_empty_disallowed(URL):
-    pook.get(URL).param_exists("x").reply(200)
+def test_param_exists_empty_disallowed(url_404):
+    pook.get(url_404).param_exists("x").reply(200)
 
     with pytest.raises(PookNoMatches):
-        urlopen(f"{URL}?x")
+        urlopen(f"{url_404}?x")
 
 
 @pytest.mark.pook
-def test_param_exists_empty_allowed(URL):
-    pook.get(URL).param_exists("x", allow_empty=True).reply(200)
+def test_param_exists_empty_allowed(url_404):
+    pook.get(url_404).param_exists("x", allow_empty=True).reply(200)
 
-    res = urlopen(f"{URL}?x")
+    res = urlopen(f"{url_404}?x")
     assert res.status == 200

--- a/tests/unit/mock_engine_test.py
+++ b/tests/unit/mock_engine_test.py
@@ -59,13 +59,12 @@ def test_mock_engine_status(engine):
     reason="Pook cannot disambiguate the two mocks. Ideally it would try to find the most specific mock that matches, but that's not possible yet."
 )
 @pytest.mark.pook(allow_pending_mocks=True)
-def test_mock_specificity(httpbin):
-    url404 = f"{httpbin.url}/status/404"
-    pook.get(url404).header_present("authorization").reply(201)
-    pook.get(url404).headers({"Authorization": "Bearer pook"}).reply(200)
+def test_mock_specificity(url_404):
+    pook.get(url_404).header_present("authorization").reply(201)
+    pook.get(url_404).headers({"Authorization": "Bearer pook"}).reply(200)
 
     res_with_headers = urlopen(
-        Request(url404, headers={"Authorization": "Bearer pook"})
+        Request(url_404, headers={"Authorization": "Bearer pook"})
     )
 
     assert res_with_headers.status == 200


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Fixes #XXX -->
Fix #159 by removing httpbin and replacing it with a minimal version of a status-echo server in Falcon. This is sufficient for pook's testing needs. Additional functionality can be added to the `local_responder` as needed.

## PR Checklist

- [x] I've added tests for any code changes
- [x] I've documented any new features
