### PR TITLE
Fix type of aiohttp raw headers

### DIFF
--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -139,7 +139,9 @@ class AIOHTTPInterceptor(BaseInterceptor):
         _res.reason = http_reasons.get(res._status)
 
         # Add response headers
-        _res._raw_headers = tuple(headers)
+        _res._raw_headers = tuple(
+            [(bytes(k, "utf-8"), bytes(v, "utf-8")) for k, v in headers]
+        )
         _res._headers = multidict.CIMultiDictProxy(multidict.CIMultiDict(headers))
 
         if res._body:


### PR DESCRIPTION
## Description
aiohttp's [`ClientResponse.raw_headers`](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.raw_headers) is supposed to by _"unconverted bytes"_.

Pook was setting the keys and values of `raw_headers` as `string` instead of `bytes`.

This was causing issues in clients which expect the headers to be `bytes`, for example `aiobotocore` tries to `decode()` header names and values which then fails with `AttributeError: 'str' object has no attribute 'decode'`.
See https://github.com/aio-libs/aiobotocore/blob/master/aiobotocore/endpoint.py#L41-L56

## PR Checklist

- [ ] I've added tests for any code changes
- [ ] I've documented any new features
