### PR TITLE
Fix aiohttp tuple parameters handling

### DIFF
--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -95,11 +95,11 @@ class AIOHTTPInterceptor(BaseInterceptor):
         if not kw.get("params"):
             req.url = str(full_url)
         else:
-            req.url = (
-                str(full_url)
-                + "?"
-                + urlencode([(x, y) for x, y in kw["params"].items()])
-            )
+            # Transform params as a list of tuple
+            params = kw["params"]
+            if isinstance(params, dict):
+                params = [(x, y) for x, y in kw["params"].items()]
+            req.url = str(full_url) + "?" + urlencode(params)
 
         # If a json payload is provided, serialize it for JSONMatcher support
         if json_body := kw.get("json"):

--- a/tests/unit/interceptors/aiohttp_test.py
+++ b/tests/unit/interceptors/aiohttp_test.py
@@ -109,3 +109,27 @@ async def test_client_headers_both_session_and_request(local_responder):
         )
         assert res.status == 200
         assert await res.read() == b"hello from pook"
+
+
+@pytest.mark.asyncio
+async def test_client_params_dict(local_responder):
+    """ "Params using dict"""
+    pook.get(local_responder + "/status/404").reply(200)
+    async with aiohttp.ClientSession(base_url=local_responder.url) as session:
+        res = await session.get("/status/404", params={"key": "value"})
+        assert res.status == 200
+        assert res.url.query.get("key") == "value"
+        assert res.url.query.getall("key") == ["value"]
+
+
+@pytest.mark.asyncio
+async def test_client_params_tuple_of_tuple(local_responder):
+    """ "Params using tuple of tuple for multiple parameter key usage"""
+    pook.get(local_responder + "/status/404").reply(200)
+    async with aiohttp.ClientSession(base_url=local_responder.url) as session:
+        res = await session.get(
+            "/status/404", params=(("key", "value"), ("key", "another-value"))
+        )
+        assert res.status == 200
+        assert res.url.query.get("key") == "value"
+        assert res.url.query.getall("key") == ["value", "another-value"]


### PR DESCRIPTION
## Description
This pull request is about handling `aiohttp` parameters as tuple of tuples or list of tuples instead of `dict`.

Pook was failing to compose `URL` for `aiohttp` interceptor because it was only using it could be a `dict`.

See aiohttp documentation about parameters:     git push --set-upstream origin fix/aiohttp-params-as-tuple

## PR Checklist

- [x] I've added tests for any code changes
- [ ] I've documented any new features
