### PR TITLE
interceptors/urllib3: return version and version_string in response

### DIFF
--- a/src/pook/interceptors/urllib3.py
+++ b/src/pook/interceptors/urllib3.py
@@ -163,6 +163,8 @@ class Urllib3Interceptor(BaseInterceptor):
             preload_content=False,
             reason=http_reasons.get(res._status),
             original_response=FakeResponse(method, headers),
+            version=11,
+            version_string="HTTP/1.1",
         )
 
     def _patch(self, path):

--- a/tests/unit/interceptors/urllib3_test.py
+++ b/tests/unit/interceptors/urllib3_test.py
@@ -106,3 +106,13 @@ def test_post_with_headers(url_404):
     resp = http.request("POST", url_404)
     assert resp.status == 200
     assert len(mock.matches) == 1
+
+
+@pytest.mark.pook
+def test_sets_version(url_404):
+    pook.get(url_404).reply(200)
+    http = urllib3.PoolManager()
+    resp = http.request("GET", url_404)
+    assert resp.status == 200
+    assert resp.version == 11
+    assert resp.version_string == "HTTP/1.1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Fixes #XXX -->

Add missing version and a version_string that are available in urllib3 response:

```
>>> import urllib3
>>> resp = urllib3.request("GET", "https://httpbin.org/robots.txt")
>>> resp.version
11
>>> resp.version_string
'HTTP/1.1'
```

## PR Checklist

- [x] I've added tests for any code changes
- [ ] I've documented any new features
