### PR TITLE
fix: aiohttp interceptor compatibility with aiohttp 4.x

### DIFF
--- a/src/pook/interceptors/aiohttp.py
+++ b/src/pook/interceptors/aiohttp.py
@@ -1,5 +1,5 @@
 from http.client import responses as http_reasons
-from typing import Optional
+from typing import Optional, Callable
 from unittest import mock
 from urllib.parse import urlunparse
 
@@ -21,7 +21,7 @@ RESPONSE_PATH = "aiohttp.client_reqrep"
 class AIOHTTPInterceptor(BaseInterceptor):
     # Implements aiohttp.ClientMiddlewareType
     async def __call__(
-        self, request: aiohttp.ClientRequest, handler: aiohttp.ClientHandlerType
+        self, request: aiohttp.ClientRequest, handler: Callable
     ) -> aiohttp.ClientResponse:
         req = Request(
             method=request.method,


### PR DESCRIPTION
## Problem
  `aiohttp.ClientHandlerType` was removed in aiohttp 4.0, causing an `AttributeError` when pook's aiohttp interceptor is loaded with aiohttp 4.x installed.

Affected line: `src/pook/interceptors/aiohttp.py` — the `__call__` signature uses `aiohttp.ClientHandlerType` as a type annotation.

## Fix
Replace `aiohttp.ClientHandlerType` with `Callable` from `typing`, which is the correct approach for aiohttp 4.x and remains backwards compatible.

## Reproduction
Pin `aiohttp>=4` and run any test suite that imports pook's aiohttp interceptor — test collection will fail.

Workaround used downstream: pin `aiohttp<4`