### PR TITLE
urllib: set Content-Length header in the response

### DIFF
--- a/src/pook/interceptors/http.py
+++ b/src/pook/interceptors/http.py
@@ -1,5 +1,6 @@
+import io
 import socket
-from http.client import _CS_REQ_SENT, HTTPMessage  # type: ignore[attr-defined]
+from http.client import _CS_REQ_SENT, parse_headers # type: ignore[attr-defined]
 from http.client import HTTPSConnection
 
 from http.client import (
@@ -75,8 +76,10 @@ class HTTPClientInterceptor(BaseInterceptor):
         # urllib requires `code` to be set, rather than `status`
         mockres.code = res._status
         mockres.reason = http_reasons.get(res._status)
-        mockres.headers = HTTPMessage()
-        mockres.length = len(res._body or b"")
+        content_length = len(res._body or b"")
+        headers_fp = io.BytesIO(f"Content-Length: {content_length}\r\n".encode("iso-8859-1"))
+        mockres.headers = parse_headers(headers_fp)
+        mockres.length = content_length
 
         for hkey, hval in res._headers.itermerged():
             mockres.headers.add_header(hkey, hval)

--- a/src/pook/interceptors/http.py
+++ b/src/pook/interceptors/http.py
@@ -1,6 +1,6 @@
 import io
 import socket
-from http.client import _CS_REQ_SENT, parse_headers # type: ignore[attr-defined]
+from http.client import _CS_REQ_SENT, parse_headers  # type: ignore[attr-defined]
 from http.client import HTTPSConnection
 
 from http.client import (
@@ -77,7 +77,9 @@ class HTTPClientInterceptor(BaseInterceptor):
         mockres.code = res._status
         mockres.reason = http_reasons.get(res._status)
         content_length = len(res._body or b"")
-        headers_fp = io.BytesIO(f"Content-Length: {content_length}\r\n".encode("iso-8859-1"))
+        headers_fp = io.BytesIO(
+            f"Content-Length: {content_length}\r\n".encode("iso-8859-1")
+        )
         mockres.headers = parse_headers(headers_fp)
         mockres.length = content_length
 

--- a/tests/unit/interceptors/urllib_test.py
+++ b/tests/unit/interceptors/urllib_test.py
@@ -37,8 +37,9 @@ def test_urllib_ssl():
     res = urlopen("https://example.com")
 
     assert res.read() == b"Hello from pook"
-    assert res.length == 15
     assert res.version == 11
+    assert res.length == 15
+    assert res.headers.get("Content-Length") == "15"
 
 
 @pytest.mark.pook
@@ -47,7 +48,9 @@ def test_urllib_clear():
     res = urlopen("http://example.com")
 
     assert res.read() == b"Hello from pook"
+    assert res.version == 11
     assert res.length == 15
+    assert res.headers.get("Content-Length") == "15"
 
 
 @pytest.mark.pook
@@ -56,5 +59,6 @@ def test_without_body_response_length_is_zero():
     res = urlopen("http://example.com")
 
     assert res.read() == b""
-    assert res.length == 0
     assert res.version == 11
+    assert res.length == 0
+    assert res.headers.get("Content-Length") == "0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Fixes #XXX -->

This updates the urllib interceptor to also set the Content-Length header in the response headers.

## PR Checklist

- [x] I've added tests for any code changes
- [ ] I've documented any new features
