### PR TITLE
fix: coerce numeric query param expectations to string when matching

### DIFF
--- a/src/pook/matchers/query.py
+++ b/src/pook/matchers/query.py
@@ -3,6 +3,13 @@ from urllib.parse import parse_qs
 from .base import BaseMatcher, ExistsMatcher
 
 
+def _to_query_value(value):
+    # Query string values are always strings; coerce numeric expectations
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return value
+
+
 class QueryMatcher(BaseMatcher):
     """
     QueryMatcher implements an URL query params matcher.
@@ -17,8 +24,11 @@ class QueryMatcher(BaseMatcher):
             # Normalize param value
             param = [param] if not isinstance(param, list) else param
 
-            # Compare query params
-            [[self.compare(value, expect) for expect in match] for value in param]
+            # Compare query params, coercing numeric expectations to str
+            [
+                [self.compare(_to_query_value(value), expect) for expect in match]
+                for value in param
+            ]
 
             return True
 

--- a/tests/unit/matchers/query_test.py
+++ b/tests/unit/matchers/query_test.py
@@ -20,3 +20,11 @@ def test_param_exists_empty_allowed(url_404):
 
     res = urlopen(f"{url_404}?x")
     assert res.status == 200
+
+
+@pytest.mark.pook
+def test_params_numeric_value(url_404):
+    pook.get(url_404).params({"x": 1}).reply(200)
+
+    res = urlopen(f"{url_404}?x=1")
+    assert res.status == 200


### PR DESCRIPTION
## Description

Query string values are always strings, so `pook.get(url).params({"x": 1})` failed to match a request to `?x=1` with `QueryMatcher: 1 != '1'`. This coerces numeric (int/float) query param expectations to `str` before comparison, leaving strings and regexes untouched. Fixes #109.

## PR Checklist

- [x] I've added tests for any code changes
- [ ] I've documented any new features